### PR TITLE
WIP: Add shell_execute and properties list for given object

### DIFF
--- a/deps/rules/julia.rules
+++ b/deps/rules/julia.rules
@@ -1,0 +1,6 @@
+
+function complete_property($$) {
+   my ($po,$prefix) = @_;
+   return new Array<String>(Core::Shell::Helper::try_property_completion($po->type,$prefix));
+}
+

--- a/deps/src/polymake.cpp
+++ b/deps/src/polymake.cpp
@@ -122,6 +122,21 @@ JLCXX_MODULE define_module_polymake(jlcxx::Module& polymake)
   POLYMAKE_INSERT_TYPE_IN_MAP(pm_Set_Int64);
   POLYMAKE_INSERT_TYPE_IN_MAP(pm_Set_Int32);
 
+  polymake.method("shell_execute",[](const std::string x)
+    {
+      // FIXME: tuples with strings are broken in cxxwrap
+      // return res;
+      // instead we return one long string now
+      auto res = data.main_polymake_session->shell_execute(x);
+      std::ostringstream output;
+      output << std::get<1>(res);
+      if (std::get<2>(res).length() > 0)
+         output << "ERR: " << std::get<2>(res);
+      if (std::get<3>(res).length() > 0)
+         output << "EXC: " << std::get<3>(res);
+      return output.str();
+    });
+
   polymake_module_add_caller(polymake);
 
 //   polymake.method("cube",[](pm::perl::Value a1, pm::perl::Value a2, pm::perl::Value a3, pm::perl::OptionSet opt){ return polymake::polytope::cube<pm::QuadraticExtension<pm::Rational> >(a1,a2,a3,opt); });

--- a/deps/src/polymake_functions.cpp
+++ b/deps/src/polymake_functions.cpp
@@ -5,7 +5,9 @@
 
 void initialize_polymake(){
     data.main_polymake_session = new polymake::Main;
+    data.main_polymake_session->shell_enable();
     data.main_polymake_scope = new polymake::perl::Scope(data.main_polymake_session->newScope());
+
     std::cout << data.main_polymake_session->greeting() << std::endl;
 }
 

--- a/src/Polymake.jl
+++ b/src/Polymake.jl
@@ -47,6 +47,8 @@ const C_TYPES = [
 function __init__()
     @initcxx
     initialize_polymake()
+    application("common")
+    shell_execute("include(\"$(joinpath(@__DIR__, "..", "deps", "rules", "julia.rules"))\");")
     application("polytope")
 
     # We need to set the Julia types as c types for polymake
@@ -65,6 +67,7 @@ include("rationals.jl")
 include("sets.jl")
 include("vectors.jl")
 include("matrices.jl")
+include("shell_helpers.jl")
 include("generated/includes.jl")
 
 end # of module Polymake

--- a/src/shell_helpers.jl
+++ b/src/shell_helpers.jl
@@ -1,0 +1,6 @@
+
+
+function complete_property(obj::pm_perl_Object,prefix::String)
+   return Polymake.call_function("complete_property",Array{Any,1}([obj,prefix]))
+end
+


### PR DESCRIPTION
For tab completion of given perl::Object, with a given prefix string which can be empty.
Note that this will not list methods like VISUAL, they will probably come via the parser and we need to merge them into the list for the output.
(If needed I might also look at other ways to get the list of possible methods)

I also added shell execute which was needed to add a custom rule file, this way we can define arbitrary polymake code (as polymake 'function') which can then be used via call_function as long as we can handle the return-type.

For the tab completion the return is Array<std::string>, i.e. this needs Mareks [enh/array_string](https://github.com/kalmarek/Polymake.jl/tree/enh/array_string) branch, then we can add an explicit to_array_string for the julia function, for now it is just an opaque PropertyValue.