### PR TITLE
WIP: restructure propertyvaluehelper and add is_boolean

### DIFF
--- a/deps/src/polymake.cpp
+++ b/deps/src/polymake.cpp
@@ -14,8 +14,6 @@
 
 #include "polymake_caller.h"
 
-#include <cxxabi.h>
-
 Polymake_Data data;
 
 JLCXX_MODULE define_module_polymake(jlcxx::Module& polymake)
@@ -129,45 +127,9 @@ JLCXX_MODULE define_module_polymake(jlcxx::Module& polymake)
   polymake.method("to_double",[](pm::perl::PropertyValue p){ return static_cast<double>(p);});
   polymake.method("to_perl_object",&to_perl_object);
 
-  polymake.method("typeinfo_string", [](pm::perl::PropertyValue p, bool demangle) -> std::string
-    {
-      PropertyValueHelper ph(p);
-
-      if (!ph.is_defined()) {
-        return "undefined";
-      }
-      if (ph.is_boolean()) {
-        return "bool";
-      }
-      switch (ph.classify_number()) {
-      // primitives
-      case PropertyValueHelper::number_is_zero:
-      case PropertyValueHelper::number_is_int:
-        return "int";
-      case PropertyValueHelper::number_is_float:
-        return "double";
-
-      // with typeinfo ptr (nullptr for Objects)
-      case PropertyValueHelper::number_is_object:
-        // some non-primitive Scalar type with typeinfo (e.g. Rational)
-      case PropertyValueHelper::not_a_number:
-        // a c++ type with typeinfo or a perl Object
-        {
-          const std::type_info* ti = ph.get_canned_typeinfo();
-          if (ti == nullptr) {
-            return "perl::Object";
-          }
-          // demangle:
-          int status = -1;
-          std::unique_ptr<char, void(*)(void*)> res {
-            abi::__cxa_demangle(ti->name(), NULL, NULL, &status),
-            std::free
-          };
-          return (status==0 && demangle) ? res.get() : ti->name();
-        }
-      }
-      return "unknown";
-    });
+  polymake.method("typeinfo_string", [](pm::perl::PropertyValue p, bool demangle) {
+    return typeinfo_helper(p, demangle);
+  });
   polymake.method("check_defined",[]( pm::perl::PropertyValue v){ return PropertyValueHelper(v).is_defined(); });
 
 

--- a/deps/src/polymake_functions.cpp
+++ b/deps/src/polymake_functions.cpp
@@ -3,6 +3,9 @@
 #include "polymake_caller.h"
 #include "polymake_functions.h"
 
+#include <typeinfo>
+#include <cxxabi.h>
+
 void initialize_polymake(){
     data.main_polymake_session = new polymake::Main;
     data.main_polymake_session->shell_enable();
@@ -27,4 +30,43 @@ pm::perl::Object to_perl_object(pm::perl::PropertyValue v){
     pm::perl::Object obj;
     v >> obj;
     return v;
+}
+
+std::string typeinfo_helper(pm::perl::PropertyValue p, bool demangle) {
+    PropertyValueHelper ph(p);
+
+    if (!ph.is_defined()) {
+      return "undefined";
+    }
+    if (ph.is_boolean()) {
+      return "bool";
+    }
+    switch (ph.classify_number()) {
+    // primitives
+    case PropertyValueHelper::number_is_zero:
+    case PropertyValueHelper::number_is_int:
+      return "int";
+    case PropertyValueHelper::number_is_float:
+      return "double";
+
+    // with typeinfo ptr (nullptr for Objects)
+    case PropertyValueHelper::number_is_object:
+      // some non-primitive Scalar type with typeinfo (e.g. Rational)
+    case PropertyValueHelper::not_a_number:
+      // a c++ type with typeinfo or a perl Object
+      {
+        const std::type_info* ti = ph.get_canned_typeinfo();
+        if (ti == nullptr) {
+          return "perl::Object";
+        }
+        // demangle:
+        int status = -1;
+        std::unique_ptr<char, void(*)(void*)> res {
+          abi::__cxa_demangle(ti->name(), NULL, NULL, &status),
+          std::free
+        };
+        return (status==0 && demangle) ? res.get() : ti->name();
+      }
+    }
+    return "unknown";
 }

--- a/deps/src/polymake_functions.h
+++ b/deps/src/polymake_functions.h
@@ -12,6 +12,8 @@ polymake::perl::Object call_func_2args(std::string, int, int);
 
 pm::perl::Object to_perl_object(pm::perl::PropertyValue);
 
+std::string typeinfo_helper(pm::perl::PropertyValue p, bool demangle);
+
 template<typename T>
 T to_SmallObject(pm::perl::PropertyValue pv){
     T obj = pv;

--- a/deps/src/polymake_tools.h
+++ b/deps/src/polymake_tools.h
@@ -17,40 +17,21 @@ class PropertyValueHelper : public pm::perl::PropertyValue {
    public:
       PropertyValueHelper(const pm::perl::PropertyValue& pv) : pm::perl::PropertyValue(pv) {};
 
-      bool check_defined() const noexcept{
-         return this->is_defined();
-      }
-      std::string get_typename() {
-         if(!this->is_defined()){
-             return "undefined";
-         }
-         switch (this->classify_number()) {
+   // in some form these will be moved to the polymake code
+   bool is_boolean() const
+   {
+      return call_function("is_boolean",*this);
+   };
 
-         // primitives
-         case number_is_zero:
-         case number_is_int:
-            return "int";
-         case number_is_float:
-            return "double";
+   using Value::is_defined;
+   using Value::get_canned_typeinfo;
+   using Value::classify_number;
+   using Value::number_is_zero;
+   using Value::number_is_int;
+   using Value::number_is_float;
+   using Value::number_is_object;
+   using Value::not_a_number;
 
-         // with typeinfo ptr (nullptr for Objects)
-         case number_is_object:
-            // some non-primitive Scalar type with typeinfo (e.g. Rational)
-         case not_a_number:
-            // a c++ type with typeinfo or a perl Object
-            {
-               const std::type_info* ti = this->get_canned_typeinfo();
-               if (ti == nullptr) {
-                  // perl object
-                  return "perl::Object";
-               } else {
-                  return legible_typename(*ti);
-               }
-            }
-         default:
-            throw std::runtime_error("get_typename: could not determine property type");
-         }
-      }
 };
 
 }

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -41,6 +41,7 @@ end
 
 const WrappedTypes = Dict(
     Symbol("int") => to_int,
+    Symbol("bool") => to_bool,
     Symbol("double") => to_double, 
     Symbol("perl::Object") => to_perl_object,
     Symbol("pm::Integer") => to_pm_Integer,
@@ -64,7 +65,7 @@ function Base.setproperty!(obj::pm_perl_Object, prop::Symbol, val)
 end
 
 function convert_from_property_value(obj::Polymake.pm_perl_PropertyValue)
-    type_name = Polymake.typeinfo_string(obj)
+    type_name = Polymake.typeinfo_string(obj,true)
     f = get(WrappedTypes, Symbol(type_name), identity)
     return f(obj)
 end


### PR DESCRIPTION
Dont merge yet!

- Moved most of the functionality out of the PropertyValueHelper except for what we might add in the polymake core
- Added is_boolean and enabled to_bool in that case
- Switch demangling to typeinfo->name and __cxa_demangle instead of the polymake legible_typename function which might change (and as recommended by Ewgenij).
- Make the demangle step optional.

For the type-map we will at some point need both libc++ and libstdc++ variants since the internal names of all the std:: types differ between the c++ libraries (and we need at least std::string and std::pair).
