### PR TITLE
rework converting from PropertyValue

### DIFF
--- a/src/functions.jl
+++ b/src/functions.jl
@@ -39,58 +39,39 @@ function perlobj(name::String, input_data::Pair{Symbol}...; kwargsdata...)
     return obj
 end
 
-function typename_func(typename::String)
-    if typename == "int"
-        return to_int
-    elseif typename == "double"
-        return to_double
-    elseif typename == "perl::Object"
-        return to_perl_object
-    elseif typename == "pm::Rational"
-        return to_pm_Rational
-    elseif typename == "pm::Integer"
-        return to_pm_Integer
-    elseif typename == "pm::Vector<pm::Integer>"
-        return to_vector_Integer
-    elseif typename == "pm::Vector<pm::Rational>"
-        return to_vector_Rational
-    elseif typename == "pm::Matrix<pm::Integer>"
-        return to_matrix_Integer
-    elseif typename == "pm::Matrix<pm::Rational>"
-        return to_matrix_Rational
-    elseif typename == "pm::Set<int, pm::operations::cmp>"
-        return to_set_int32
-    elseif typename == "pm::Set<long, pm::operations::cmp>"
-        return to_set_int64
-    elseif typename == "pm::Array<int>"
-        return to_array_int32
-    elseif typename == "pm::Array<long>"
-        return to_array_int64
-    elseif typename == "pm::Array<std::basic_string<char, std::char_traits<char>, std::allocator<char> >>"
-        return to_array_string
-    elseif typename == "pm::Array<pm::Set<int, pm::operations::cmp>>"
-        return to_array_set_int32
-    elseif typename == "pm::Array<pm::Matrix<pm::Integer>>"
-        return to_array_matrix_Integer
-    elseif typename == "undefined"
-        return x -> nothing
-    end
-    return identity
-end
+const WrappedTypes = Dict(
+    Symbol("int") => to_int,
+    Symbol("double") => to_double, 
+    Symbol("perl::Object") => to_perl_object,
+    Symbol("pm::Integer") => to_pm_Integer,
+    Symbol("pm::Rational") => to_pm_Rational,
+    Symbol("pm::Vector<pm::Integer>") => to_vector_Integer,
+    Symbol("pm::Vector<pm::Rational>") => to_vector_Rational,
+    Symbol("pm::Matrix<pm::Integer>") => to_matrix_Integer,
+    Symbol("pm::Matrix<pm::Rational>") => to_matrix_Rational,
+    Symbol("pm::Set<int, pm::operations::cmp>") => to_set_int32,
+    Symbol("pm::Set<long, pm::operations::cmp>") => to_set_int64,
+    Symbol("pm::Array<int>") => to_array_int32,
+    Symbol("pm::Array<long>") => to_array_int64,
+    Symbol("pm::Array<std::basic_string<char, std::char_traits<char>, std::allocator<char> >>") => to_array_string,
+    Symbol("pm::Array<pm::Set<int, pm::operations::cmp>>") => to_array_set_int32,
+    Symbol("pm::Array<pm::Matrix<pm::Integer>>") => to_array_matrix_Integer, 
+    Symbol("undefined") => x -> nothing,
+)
 
 function Base.setproperty!(obj::pm_perl_Object, prop::Symbol, val)
     take(obj, string(prop), convert_to_pm(val))
 end
 
-function Base.getproperty(obj::pm_perl_Object, prop::Symbol)
-    return_obj = internal_give(obj, string(prop))
-    type_name = typeinfo_string(return_obj)
-    return typename_func(type_name)(return_obj)
-end
-
 function convert_from_property_value(obj::Polymake.pm_perl_PropertyValue)
     type_name = Polymake.typeinfo_string(obj)
-    return typename_func(type_name)(obj)
+    f = get(WrappedTypes, Symbol(type_name), identity)
+    return f(obj)
+end
+
+function Base.getproperty(obj::pm_perl_Object, prop::Symbol)
+    return_obj = internal_give(obj, string(prop))
+    return convert_from_property_value(return_obj)
 end
 
 function give(obj::Polymake.pm_perl_Object,prop::String)


### PR DESCRIPTION
we can have a discussion here about this;

The other options:
 * `WrappedTypes` is `Dict{Symbol,Type}` and we obtain `T` which we use to `convert(T, obj::PropertyValue)
 * some `@generated` function which automatically populates another `Dictionary{Symbol, Function}` at runtime
 * any other fancy meta-stuff which I have no idea about