### PR TITLE
Add `call_method_void`

### DIFF
--- a/deps/src/polymake_caller.cpp
+++ b/deps/src/polymake_caller.cpp
@@ -97,7 +97,6 @@ void polymake_call_method_void(std::string function_name, pm::perl::Object objec
         polymake_call_function_feed_argument(function, arguments[i]);
     }
     function();
-    return;
 }
 
 

--- a/deps/src/polymake_caller.cpp
+++ b/deps/src/polymake_caller.cpp
@@ -89,8 +89,21 @@ pm::perl::PropertyValue polymake_call_method(std::string function_name, pm::perl
     return function();
 }
 
+void polymake_call_method_void(std::string function_name, pm::perl::Object object, jlcxx::ArrayRef<jl_value_t*> arguments)
+{
+    size_t argument_list = arguments.size();
+    auto function = object.prepare_call_method(function_name);
+    for(size_t i = 0;i<argument_list;i++){
+        polymake_call_function_feed_argument(function, arguments[i]);
+    }
+    function();
+    return;
+}
+
+
 void polymake_module_add_caller(jlcxx::Module& polymake){
     polymake.method("call_function",&polymake_call_function);
     polymake.method("call_method",&polymake_call_method);
+    polymake.method("call_method_void",&polymake_call_method_void);
     polymake.method("set_julia_type",&set_julia_type);
 }


### PR DESCRIPTION
Polymake is quite opinionated when to show a visualization. In particular the method has to be called in a void context. We therefore need a new `call_method_void` which throws away the return value...

With this
```julia
julia> c = cube(3);

julia> Polymake.call_method_void("VISUAL", c, [])
polymake: used package jreality
  jReality is a visualization and sonification library focused on mathematical and scientific content.
  http://www3.math.tu-berlin.de/jreality
```
works :)

@benlorenz figured this out :)

How we expose this to the user is another question and there is already enough bike shedding today, so I will punt on this for now...