### PR TITLE
add to_string for PropertyValue, used as fallback for print

### DIFF
--- a/deps/src/polymake.cpp
+++ b/deps/src/polymake.cpp
@@ -73,6 +73,9 @@ JLCXX_MODULE define_module_polymake(jlcxx::Module& polymake)
   polymake.method("to_matrix_Rational", [](pm::perl::PropertyValue pv){
     return to_SmallObject<pm::Matrix<pm::Rational>>(pv);
   });
+  polymake.method("to_string", [](pm::perl::PropertyValue pv){
+    return to_SmallObject<std::string>(pv);
+  });
     
   POLYMAKE_INSERT_TYPE_IN_MAP(pm_Matrix_pm_Integer);
   POLYMAKE_INSERT_TYPE_IN_MAP(pm_Matrix_pm_Rational);

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -95,4 +95,9 @@ end
 function Base.show(io::IO, ::MIME"text/plain", obj::SmallObject)
     print(io, show_small_obj(obj))
 end
+
+# fallback for non-wrapped types
+function Base.show(io::IO, ::MIME"text/plain", pv::pm_perl_PropertyValue)
+    print(io, to_string(pv))
+end
 Base.show(io::IO, obj::SmallObject) = show(io, MIME("text/plain"), obj)


### PR DESCRIPTION
it turns out that any PropertyValue (probably except for BigObject and related types) can be converted to std::string, which we can use as fallback for printing unwrapped types:
```
julia> cube(3).FACETS
┌ Warning: The return value contains pm::SparseMatrix<pm::Rational, pm::NonSymmetric> which has not been wrapped yet
└ @ Polymake ~/software/polymake/julia/Polymake.jl/src/functions.jl:75
1 1 0 0
1 -1 0 0
1 0 1 0
1 0 -1 0
1 0 0 1
1 0 0 -1
```

we should probably add some tests