### PR TITLE
Remove old call_func_*args functions and add new convenience call_func

### DIFF
--- a/deps/src/polymake_functions.cpp
+++ b/deps/src/polymake_functions.cpp
@@ -16,18 +16,6 @@ void initialize_polymake(){
     }
 }
 
-polymake::perl::Object call_func_0args(std::string func) {
-    return polymake::call_function(func);
-}
-
-polymake::perl::Object call_func_1args(std::string func, int arg1) {
-    return polymake::call_function(func, arg1);
-}
-
-polymake::perl::Object call_func_2args(std::string func, int arg1, int arg2) {
-    return polymake::call_function(func, arg1, arg2);
-}
-
 pm::perl::Object to_perl_object(pm::perl::PropertyValue v){
     pm::perl::Object obj;
     v >> obj;

--- a/deps/src/polymake_functions.h
+++ b/deps/src/polymake_functions.h
@@ -4,12 +4,6 @@
 
 void initialize_polymake();
 
-polymake::perl::Object call_func_0args(std::string);
-
-polymake::perl::Object call_func_1args(std::string, int);
-
-polymake::perl::Object call_func_2args(std::string, int, int);
-
 pm::perl::Object to_perl_object(pm::perl::PropertyValue);
 
 template<typename T>

--- a/test/interface_functions.jl
+++ b/test/interface_functions.jl
@@ -1,0 +1,4 @@
+@testset "Interface functions" begin
+    @test call_func(:pseudopower, pm_Integer(4), 2) == 5
+    @test call_func(:cube, 2) isa pm_perl_Object
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -14,4 +14,5 @@ end
     include("sets.jl")
     include("arrays.jl")
     include("perlobj.jl")
+    include("interface_functions.jl")
 end


### PR DESCRIPTION
This came up in a discussion with Michael. We currently have some old `call_func_0args`, `call_func_1args` and `call_func_2args` functions lying around. I removed them and replaced them with a new varargs `call_func` method (mostly as an intermediate step until we covered everything by our code generation).