### PR TITLE
BigObjectArrays, types and more

### DIFF
--- a/deps/parser/type_setup.jl
+++ b/deps/parser/type_setup.jl
@@ -18,7 +18,8 @@ type_tuples = [
 ( "pm_Array_pm_Array_Int32",       "pm::Array<pm::Array<int32_t>>",      "pm_Array{pm_Array{Int32}}",       "to_array_array_int32" ),
 ( "pm_Array_pm_Array_Int64",       "pm::Array<pm::Array<long>>",         "pm_Array{pm_Array{Int64}}",       "to_array_array_int64" ),
 ( "pm_Array_pm_Array_pm_Integer",  "pm::Array<pm::Array<pm::Integer>>",  "pm_Array{pm_Array{pm_Integer}}",  "to_array_array_Integer" ),
-( "pm_Array_pm_Matrix_pm_Integer", "pm::Array<pm::Matrix<pm::Integer>>", "pm_Array{pm_Matrix{pm_Integer}}", "to_array_matrix_Integer" )
+( "pm_Array_pm_Matrix_pm_Integer", "pm::Array<pm::Matrix<pm::Integer>>", "pm_Array{pm_Matrix{pm_Integer}}", "to_array_matrix_Integer" ),
+( "pm_Array_pm_perl_Object",       "pm::Array<pm::perl::Object>",        "pm_Array{pm_perl_Object}",        "to_array_perl_object" ),
 ]
 
 type_var_file = abspath( @__DIR__, "..", "src", "generated", "type_vars.h" )

--- a/deps/rules/julia.rules
+++ b/deps/rules/julia.rules
@@ -23,3 +23,19 @@ function list_big_objects($) {
    my ($app) = @_;
    return new Array<String>(uniq(map {$_->name} @{User::application($app)->object_types}));
 }
+
+# map some perl based types without typeinfo to c++ types
+function classify_perl_pv($) {
+   my ($pv) = @_;
+   return "pm::perl::Object"
+      if instanceof Polymake::Core::Object($pv);
+   return "pm::perl::ObjectType"
+      if instanceof Polymake::Core::ObjectType($pv);
+   return "pm::Array<pm::perl::Object>"
+      if instanceof Polymake::Core::BigObjectArray($pv);
+   # a plain perl string is also done here
+   return "std::string"
+      if is_string($pv);
+   # ref will return some string representation of the perl object type
+   return ref($pv);
+}

--- a/deps/src/polymake_arrays.cpp
+++ b/deps/src/polymake_arrays.cpp
@@ -83,32 +83,32 @@ void polymake_module_add_array(jlcxx::Module& polymake)
             });
         });
 
-    polymake.method("to_array_int32", [](pm::perl::PropertyValue pv) {
+    polymake.method("to_array_int32", [](const pm::perl::PropertyValue& pv) {
         return to_SmallObject<pm::Array<int32_t>>(pv);
     });
-    polymake.method("to_array_int64", [](pm::perl::PropertyValue pv) {
+    polymake.method("to_array_int64", [](const pm::perl::PropertyValue& pv) {
         return to_SmallObject<pm::Array<long>>(pv);
     });
-    polymake.method("to_array_Integer", [](pm::perl::PropertyValue pv) {
+    polymake.method("to_array_Integer", [](const pm::perl::PropertyValue& pv) {
         return to_SmallObject<pm::Array<pm::Integer>>(pv);
     });
-    polymake.method("to_array_string", [](pm::perl::PropertyValue pv) {
+    polymake.method("to_array_string", [](const pm::perl::PropertyValue& pv) {
         return to_SmallObject<pm::Array<std::string>>(pv);
     });
-    polymake.method("to_array_array_int32", [](pm::perl::PropertyValue pv) {
+    polymake.method("to_array_array_int32", [](const pm::perl::PropertyValue& pv) {
         return to_SmallObject<pm::Array<pm::Array<int32_t>>>(pv);
     });
-    polymake.method("to_array_array_int64", [](pm::perl::PropertyValue pv) {
+    polymake.method("to_array_array_int64", [](const pm::perl::PropertyValue& pv) {
         return to_SmallObject<pm::Array<pm::Array<long>>>(pv);
     });
-    polymake.method("to_array_array_Integer", [](pm::perl::PropertyValue pv) {
+    polymake.method("to_array_array_Integer", [](const pm::perl::PropertyValue& pv) {
         return to_SmallObject<pm::Array<pm::Array<pm::Integer>>>(pv);
     });
-    polymake.method("to_array_set_int32", [](pm::perl::PropertyValue pv) {
+    polymake.method("to_array_set_int32", [](const pm::perl::PropertyValue& pv) {
         return to_SmallObject<pm::Array<pm::Set<int32_t>>>(pv);
     });
     polymake.method(
-        "to_array_matrix_Integer", [](pm::perl::PropertyValue pv) {
+        "to_array_matrix_Integer", [](const pm::perl::PropertyValue& pv) {
             return to_SmallObject<pm::Array<pm::Matrix<pm::Integer>>>(pv);
         });
     polymake.method(

--- a/deps/src/polymake_arrays.cpp
+++ b/deps/src/polymake_arrays.cpp
@@ -57,6 +57,30 @@ void polymake_module_add_array(jlcxx::Module& polymake)
             wrapped.method("take",
                            [](pm::perl::Object p, const std::string& s,
                               WrappedT& A) { p.take(s) << A; });
+        })
+        .apply<pm::Array<pm::perl::Object>>([](auto wrapped) {
+            typedef typename decltype(wrapped)::type             WrappedT;
+            typedef perl::Object elemType;
+
+            wrapped.template constructor<int32_t>();
+            wrapped.template constructor<int64_t>();
+
+            wrapped.method("_getindex", [](const WrappedT& A, int64_t n) {
+                return elemType(A[static_cast<long>(n) - 1]);
+            });
+            wrapped.method("_setindex!",
+                           [](WrappedT& A, const elemType& val, int64_t n) {
+                               A[static_cast<long>(n) - 1] = val;
+                           });
+            wrapped.method("length", &WrappedT::size);
+            wrapped.method("resize!", [](WrappedT& A, int64_t newsz) {
+                A.resize(static_cast<long>(newsz));
+                return A;
+            });
+            wrapped.method("resize!", [](WrappedT& A, int32_t newsz) {
+                A.resize(static_cast<long>(newsz));
+                return A;
+            });
         });
 
     polymake.method("to_array_int32", [](pm::perl::PropertyValue pv) {
@@ -86,5 +110,9 @@ void polymake_module_add_array(jlcxx::Module& polymake)
     polymake.method(
         "to_array_matrix_Integer", [](pm::perl::PropertyValue pv) {
             return to_SmallObject<pm::Array<pm::Matrix<pm::Integer>>>(pv);
+        });
+    polymake.method(
+        "to_array_perl_object", [](const pm::perl::PropertyValue& pv) {
+            return to_SmallObject<pm::Array<pm::perl::Object>>(pv);
         });
 }

--- a/deps/src/polymake_arrays.cpp
+++ b/deps/src/polymake_arrays.cpp
@@ -59,8 +59,8 @@ void polymake_module_add_array(jlcxx::Module& polymake)
                               WrappedT& A) { p.take(s) << A; });
         })
         .apply<pm::Array<pm::perl::Object>>([](auto wrapped) {
-            typedef typename decltype(wrapped)::type             WrappedT;
-            typedef perl::Object elemType;
+            typedef typename decltype(wrapped)::type WrappedT;
+            typedef perl::Object                     elemType;
 
             wrapped.template constructor<int32_t>();
             wrapped.template constructor<int64_t>();
@@ -89,24 +89,29 @@ void polymake_module_add_array(jlcxx::Module& polymake)
     polymake.method("to_array_int64", [](const pm::perl::PropertyValue& pv) {
         return to_SmallObject<pm::Array<long>>(pv);
     });
-    polymake.method("to_array_Integer", [](const pm::perl::PropertyValue& pv) {
-        return to_SmallObject<pm::Array<pm::Integer>>(pv);
-    });
+    polymake.method("to_array_Integer",
+                    [](const pm::perl::PropertyValue& pv) {
+                        return to_SmallObject<pm::Array<pm::Integer>>(pv);
+                    });
     polymake.method("to_array_string", [](const pm::perl::PropertyValue& pv) {
         return to_SmallObject<pm::Array<std::string>>(pv);
     });
-    polymake.method("to_array_array_int32", [](const pm::perl::PropertyValue& pv) {
-        return to_SmallObject<pm::Array<pm::Array<int32_t>>>(pv);
-    });
-    polymake.method("to_array_array_int64", [](const pm::perl::PropertyValue& pv) {
-        return to_SmallObject<pm::Array<pm::Array<long>>>(pv);
-    });
-    polymake.method("to_array_array_Integer", [](const pm::perl::PropertyValue& pv) {
-        return to_SmallObject<pm::Array<pm::Array<pm::Integer>>>(pv);
-    });
-    polymake.method("to_array_set_int32", [](const pm::perl::PropertyValue& pv) {
-        return to_SmallObject<pm::Array<pm::Set<int32_t>>>(pv);
-    });
+    polymake.method(
+        "to_array_array_int32", [](const pm::perl::PropertyValue& pv) {
+            return to_SmallObject<pm::Array<pm::Array<int32_t>>>(pv);
+        });
+    polymake.method("to_array_array_int64",
+                    [](const pm::perl::PropertyValue& pv) {
+                        return to_SmallObject<pm::Array<pm::Array<long>>>(pv);
+                    });
+    polymake.method(
+        "to_array_array_Integer", [](const pm::perl::PropertyValue& pv) {
+            return to_SmallObject<pm::Array<pm::Array<pm::Integer>>>(pv);
+        });
+    polymake.method(
+        "to_array_set_int32", [](const pm::perl::PropertyValue& pv) {
+            return to_SmallObject<pm::Array<pm::Set<int32_t>>>(pv);
+        });
     polymake.method(
         "to_array_matrix_Integer", [](const pm::perl::PropertyValue& pv) {
             return to_SmallObject<pm::Array<pm::Matrix<pm::Integer>>>(pv);

--- a/deps/src/polymake_functions.cpp
+++ b/deps/src/polymake_functions.cpp
@@ -22,14 +22,14 @@ void initialize_polymake()
     }
 }
 
-pm::perl::Object to_perl_object(pm::perl::PropertyValue v)
+pm::perl::Object to_perl_object(const pm::perl::PropertyValue& v)
 {
     pm::perl::Object obj;
     v >> obj;
     return v;
 }
 
-std::string typeinfo_helper(pm::perl::PropertyValue p, bool demangle)
+std::string typeinfo_helper(const pm::perl::PropertyValue& p, bool demangle)
 {
     PropertyValueHelper ph(p);
 

--- a/deps/src/polymake_functions.cpp
+++ b/deps/src/polymake_functions.cpp
@@ -55,7 +55,8 @@ std::string typeinfo_helper(pm::perl::PropertyValue p, bool demangle)
             {
                 const std::type_info* ti = ph.get_canned_typeinfo();
                 if (ti == nullptr) {
-                    return "pm::perl::Object";
+                    // check some perl based types via custom perl code
+                    return call_function("classify_perl_pv",p);
                 }
                 // demangle:
                 int                                    status = -1;

--- a/deps/src/polymake_functions.cpp
+++ b/deps/src/polymake_functions.cpp
@@ -56,7 +56,7 @@ std::string typeinfo_helper(const pm::perl::PropertyValue& p, bool demangle)
                 const std::type_info* ti = ph.get_canned_typeinfo();
                 if (ti == nullptr) {
                     // check some perl based types via custom perl code
-                    return call_function("classify_perl_pv",p);
+                    return call_function("classify_perl_pv", p);
                 }
                 // demangle:
                 int                                    status = -1;

--- a/deps/src/polymake_functions.h
+++ b/deps/src/polymake_functions.h
@@ -4,11 +4,11 @@
 
 void initialize_polymake();
 
-pm::perl::Object to_perl_object(pm::perl::PropertyValue);
+pm::perl::Object to_perl_object(const pm::perl::PropertyValue&);
 
-std::string typeinfo_helper(pm::perl::PropertyValue p, bool demangle);
+std::string typeinfo_helper(const pm::perl::PropertyValue& p, bool demangle);
 
-template <typename T> T to_SmallObject(pm::perl::PropertyValue pv)
+template <typename T> T to_SmallObject(const pm::perl::PropertyValue& pv)
 {
     T obj = pv;
     return obj;

--- a/deps/src/polymake_perl_objects.cpp
+++ b/deps/src/polymake_perl_objects.cpp
@@ -65,8 +65,9 @@ void polymake_module_add_perl_object(jlcxx::Module& polymake)
                 })
         .method("exists", [](pm::perl::Object   p,
                              const std::string& s) { return p.exists(s); })
-        .method("object_type", [](pm::perl::Object   p) { return p.type(); })
-        .method("type_name", [](pm::perl::Object   p) { return p.type().name(); })
+        .method("object_type", [](pm::perl::Object p) { return p.type(); })
+        .method("type_name",
+                [](pm::perl::Object p) { return p.type().name(); })
         .method("properties", [](pm::perl::Object p) {
             std::string x = p.call_method("properties");
             return x;
@@ -91,9 +92,8 @@ void polymake_module_add_perl_object(jlcxx::Module& polymake)
     polymake.method("take",
                     [](pm::perl::Object p, const std::string& s,
                        const pm::perl::Object& v) { p.take(s) << v; });
-    polymake.method("add",
-                    [](pm::perl::Object p, const std::string& s,
-                       const pm::perl::Object& v) { p.add(s,v); });
+    polymake.method("add", [](pm::perl::Object p, const std::string& s,
+                              const pm::perl::Object& v) { p.add(s, v); });
 
     polymake.method("typeinfo_string",
                     [](pm::perl::PropertyValue p, bool demangle) {

--- a/deps/src/polymake_perl_objects.cpp
+++ b/deps/src/polymake_perl_objects.cpp
@@ -45,9 +45,13 @@ void polymake_module_add_perl_object(jlcxx::Module& polymake)
 
     polymake.method("option_set_take", option_set_take);
 
+    polymake.add_type<pm::perl::ObjectType>("pm_perl_ObjectType")
+        .constructor<const std::string&>()
+        .method("name", [](pm::perl::ObjectType p) { return p.name(); });
 
     polymake.add_type<pm::perl::Object>("pm_perl_Object")
         .constructor<const std::string&>()
+        .constructor<const pm::perl::ObjectType&>()
         .method("save_perl_object",
                 [](pm::perl::Object p, const std::string& s) {
                     return p.save(s);
@@ -61,6 +65,7 @@ void polymake_module_add_perl_object(jlcxx::Module& polymake)
                 })
         .method("exists", [](pm::perl::Object   p,
                              const std::string& s) { return p.exists(s); })
+        .method("type", [](pm::perl::Object   p) { return p.type(); })
         .method("properties", [](pm::perl::Object p) {
             std::string x = p.call_method("properties");
             return x;

--- a/deps/src/polymake_perl_objects.cpp
+++ b/deps/src/polymake_perl_objects.cpp
@@ -47,7 +47,7 @@ void polymake_module_add_perl_object(jlcxx::Module& polymake)
 
     polymake.add_type<pm::perl::ObjectType>("pm_perl_ObjectType")
         .constructor<const std::string&>()
-        .method("name", [](pm::perl::ObjectType p) { return p.name(); });
+        .method("type_name", [](pm::perl::ObjectType p) { return p.name(); });
 
     polymake.add_type<pm::perl::Object>("pm_perl_Object")
         .constructor<const std::string&>()
@@ -65,7 +65,8 @@ void polymake_module_add_perl_object(jlcxx::Module& polymake)
                 })
         .method("exists", [](pm::perl::Object   p,
                              const std::string& s) { return p.exists(s); })
-        .method("type", [](pm::perl::Object   p) { return p.type(); })
+        .method("object_type", [](pm::perl::Object   p) { return p.type(); })
+        .method("type_name", [](pm::perl::Object   p) { return p.type().name(); })
         .method("properties", [](pm::perl::Object p) {
             std::string x = p.call_method("properties");
             return x;

--- a/deps/src/polymake_perl_objects.cpp
+++ b/deps/src/polymake_perl_objects.cpp
@@ -82,6 +82,12 @@ void polymake_module_add_perl_object(jlcxx::Module& polymake)
     polymake.method("take",
                     [](pm::perl::Object p, const std::string& s,
                        const pm::perl::PropertyValue& v) { p.take(s) << v; });
+    polymake.method("take",
+                    [](pm::perl::Object p, const std::string& s,
+                       const pm::perl::Object& v) { p.take(s) << v; });
+    polymake.method("add",
+                    [](pm::perl::Object p, const std::string& s,
+                       const pm::perl::Object& v) { p.add(s,v); });
 
     polymake.method("typeinfo_string",
                     [](pm::perl::PropertyValue p, bool demangle) {

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -125,4 +125,7 @@ end
 function Base.show(io::IO, ::MIME"text/plain", pv::pm_perl_PropertyValue)
     print(io, to_string(pv))
 end
+function Base.show(io::IO, ::MIME"text/plain", a::pm_Array{pm_perl_Object})
+    print(io, "pm_Array{pm_perl_Object} of size ",length(a))
+end
 Base.show(io::IO, obj::SmallObject) = show(io, MIME("text/plain"), obj)

--- a/src/vectors.jl
+++ b/src/vectors.jl
@@ -4,7 +4,7 @@ function pm_Vector(v::AbstractVector{T}) where T<:Integer
     res .= v
     return res
 end
-function pm_Vector(v::AbstractVector{T}) where T<:Rational
+function pm_Vector(v::AbstractVector{T}) where T<:Union{Rational,pm_Rational}
     res = pm_Vector{pm_Rational}(size(v)...)
     res .= v
     return res


### PR DESCRIPTION
Several improvements and additions (@lkastner ):

- determine perl based types (without type_info) via perl helper function, this allows to check whether a PropertyValue is a big object, a big object array, or something else
- add arrays of big objects, which needed a special case since they dont have the same methods as other arrays. this should help for atint and polydb
- add ObjectType (this could be used for the perlobj calls as an alternative to the type string)
- add a few take methods and an add method for multiple subobjects
- minor fix in vector construction as suggested by @saschatimme 

no tests yet...