### PR TITLE
Use CMake.jl for providing the CMake executable

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.2.0"
 
 [deps]
 BinaryProvider = "b99e7846-7c00-51b0-8f62-c81ae34c0232"
+CMake = "631607c0-34d2-5d66-819e-eb0f9aa2061a"
 CxxWrap = "1f15a43c-97ca-5a2a-ae31-89f07a497df4"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -2,6 +2,7 @@ using CxxWrap
 using BinaryProvider
 using Base.Filesystem
 import Pkg
+import CMake
 
 # Parse some basic command-line arguments
 const verbose = "--verbose" in ARGS
@@ -124,7 +125,7 @@ cd(joinpath(@__DIR__, "src"))
 
 include("parser/type_setup.jl")
 
-run(`cmake -DJulia_EXECUTABLE=$julia_exec -DJlCxx_DIR=$jlcxx_cmake_dir -Dpolymake_includes=$pm_includes -Dpolymake_ldflags=$pm_ldflags -Dpolymake_libs=$pm_libraries -Dpolymake_cflags=$pm_cflags -DCMAKE_CXX_COMPILER=$pm_cxx  -DCMAKE_INSTALL_LIBDIR=lib .`)
+run(`$(CMake.cmake) -DJulia_EXECUTABLE=$julia_exec -DJlCxx_DIR=$jlcxx_cmake_dir -Dpolymake_includes=$pm_includes -Dpolymake_ldflags=$pm_ldflags -Dpolymake_libs=$pm_libraries -Dpolymake_cflags=$pm_cflags -DCMAKE_CXX_COMPILER=$pm_cxx  -DCMAKE_INSTALL_LIBDIR=lib .`)
 run(`make -j$(div(Sys.CPU_THREADS,2))`)
 
 json_script = joinpath(@__DIR__,"rules","funtojson.pl")


### PR DESCRIPTION
This is an alternative to #113 