### PR TITLE
@pm macro et al

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ The following tables explain by example how to quickly translate `Polymake` synt
 | `convert_to<Rational>($m_int)`                               | `convert(Diagonal{Rational{Int}}, m_int)`                    |
 | `$z_vec=zero_vector<Int>($m_int->rows)`<br />`$extended_matrix=($z_vec\|$m_int);`<br />(adds `z_vec` as the first column, result is dense) | `z_vec = zeros(Int, size(m_int, 1))`<br />`extended_matrix = hcat(z_vec, m_int)`<br />(result is sparse) |
 | `$set=new Set<Int>(3,2,5);`<br />`$template_Ex=new Array<Set<Int>>((new Set<Int>(5,2,6)),$set)` | `set = Set([3,2,5]); template_Ex = [Set([5,2,6]), set]`      |
-| `$p=new Polytope<Rational>(POINTS=>cube(4)->VERTICES);`<br />`$lp=new LinearProgram<Rational>(LINEAR_OBJECTIVE=>[0,1,1,1,1]);`<br />`$p->LP=$lp;`<br />`$p->LP->MAXIMAL_VALUE;` | `p = @pm Polytopes.Polytope(:POINTS=>Polymake.polytope.cube(4).VERTICES)`<br />`lp = @pm Polytopes.LinearProgram(:LINEAR_OBJECTIVE=>[0,1,1,1,1])`<br />`p.LP = lp`<br />`p.LP.MAXIMAL_VALUE` |
+| `$p=new Polytope<Rational>(POINTS=>cube(4)->VERTICES);`<br />`$lp=new LinearProgram<Rational>(LINEAR_OBJECTIVE=>[0,1,1,1,1]);`<br />`$p->LP=$lp;`<br />`$p->LP->MAXIMAL_VALUE;` | `p = @pm Polytopes.Polytope(:POINTS=>Polymake.Polytopes.cube(4).VERTICES)`<br />`lp = @pm Polytopes.LinearProgram(:LINEAR_OBJECTIVE=>[0,1,1,1,1])`<br />`p.LP = lp`<br />`p.LP.MAXIMAL_VALUE` |
 | `$i = ($p->N_FACETS * $p->N_FACETS) * 15;`                   | `i = (p.N_FACETS * p.N_FACETS) * 15`                         |
 
 ### Example script
@@ -190,18 +190,18 @@ matrix = eval(Base.Meta.parse(matrix_str))
 p = @pm Polytopes.Polytope(:POINTS=>matrix)
 
 @show p.FACETS # polymake matrix of polymake rationals
-@show Polymake.polytope.DIM(p) # julias Int64
+@show Polymake.Polytopes.DIM(p) # julias Int64
 # note that even in Polymake property DIM is "fake" -- it's actually a function
 @show p.VERTEX_SIZES # polymake array of ints
 
 for (i, vsize) in enumerate(p.VERTEX_SIZES)
-  if vsize == Polymake.polytope.DIM(p)
+  if vsize == Polymake.Polytopes.DIM(p)
     println("$i : $(p.VERTICES[i,:])")
     # $i will be shifted by one from the polymake version
   end
 end
 
-s = [i for (i, vsize) in enumerate(p.VERTEX_SIZES) if vsize == Polymake.polytope.DIM(p)] # julias vector of Int64s
+s = [i for (i, vsize) in enumerate(p.VERTEX_SIZES) if vsize == Polymake.Polytopes.DIM(p)] # julias vector of Int64s
 # note that sets are unordered in julia
 unique!(s)
 
@@ -227,7 +227,7 @@ p.FACETS = pm::Matrix<pm::Rational>
 3 -20 16 16
 0 -1 -1 20
 
-(Polymake.polytope).DIM(p) = 3
+(Polymake.Polytopes).DIM(p) = 3
 p.VERTEX_SIZES = pm::Array<int>
 9 3 4 4 3 4 3 4 4 4
 2 : pm_Rational[1, 1/16, 1/4, 1/16]
@@ -249,10 +249,10 @@ To suppress it just execute `include("example_script.jl);`.
 The same minor (up to permutation of rows) could be obtained by using sets, or the identical minor by using (ordered) polymake sets.
 Just remember to `collect` the set to a vector when indexing `VERTICES`.
 ```julia
-s = Set(i for (i, vsize) in enumerate(p.VERTEX_SIZES) if vsize == Polymake.polytope.DIM(p))
+s = Set(i for (i, vsize) in enumerate(p.VERTEX_SIZES) if vsize == Polymake.Polytopes.DIM(p))
 # s is julias set of Int64s
 
-s = pm_Set(i for (i, vsize) in enumerate(p.VERTEX_SIZES) if vsize == Polymake.polytope.DIM(p))
+s = pm_Set(i for (i, vsize) in enumerate(p.VERTEX_SIZES) if vsize == Polymake.Polytopes.DIM(p))
 # polymake set of longs
 
 special_points = p.VERTICES[collect(s), :]

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ First clone `Polymake.jl`:
 ```
 git clone https://github.com/oscar-system/Polymake.jl.git
 ```
-In Julia REPL press `]` for `pkg` mode and 
+In Julia REPL press `]` for `pkg` mode and
 ```julia
 (v1.0) pkg> activate Polymake.jl
 (Polymake) pkg> instantiate
@@ -57,10 +57,10 @@ Just remember that You need to `activate Polymake.jl` to use `Polymake`.
 
 ## Examples
 
-polymake big objects (like `Polytope`, `Cone`, etc) can be created with the `perlobj` helper functions.
+polymake big objects (like `Polytope`, `Cone`, etc) can be created with the `@pm` macro:
 ```julia
 # Call the Polytope constructor
-julia> p = perlobj("Polytope", POINTS=[1 -1 -1; 1 1 -1; 1 -1 1; 1 1 1; 1 0 0])
+julia> p = @pm Polytopes.Polytope(POINTS=[1 -1 -1; 1 1 -1; 1 -1 1; 1 1 1; 1 0 0])
 type: Polytope<Rational>
 
 POINTS
@@ -91,7 +91,7 @@ pm::Matrix<pm::Integer>
     * Arrays
     * Sets
     * Combinations thereof, e.g., Sets of Arrays of Integers
- 
+
 The polymake data types can be converted to appropriate Julia types,
 but are also subtypes of the corresponding Julia abstract types, e.g., a
 polymake array is an `AbstractArray`, and one can call methods that
@@ -172,5 +172,88 @@ The following tables explain by example how to quickly translate `Polymake` synt
 | `convert_to<Rational>($m_int)`                               | `convert(Diagonal{Rational{Int}}, m_int)`                    |
 | `$z_vec=zero_vector<Int>($m_int->rows)`<br />`$extended_matrix=($z_vec\|$m_int);`<br />(adds `z_vec` as the first column, result is dense) | `z_vec = zeros(Int, size(m_int, 1))`<br />`extended_matrix = hcat(z_vec, m_int)`<br />(result is sparse) |
 | `$set=new Set<Int>(3,2,5);`<br />`$template_Ex=new Array<Set<Int>>((new Set<Int>(5,2,6)),$set)` | `set = Set([3,2,5]); template_Ex = [Set([5,2,6]), set]`      |
-| `$p=new Polytope<Rational>(POINTS=>cube(4)->VERTICES);`<br />`$lp=new LinearProgram<Rational>(LINEAR_OBJECTIVE=>[0,1,1,1,1]);`<br />`$p->LP=$lp;`<br />`p->LP->MAXIMAL_VALUE;` | `p = p = perlobj("Polytope", :POINTS=>Polymake.polytope.cube(4).VERTICES)`<br />`lp = perlobj("LinearProgram", :LINEAR_OBJECTIVE=>[0,1,1,1,1])`<br />`p.LP = lp`<br />`p.LP.MAXIMAL_VALUE` |
+| `$p=new Polytope<Rational>(POINTS=>cube(4)->VERTICES);`<br />`$lp=new LinearProgram<Rational>(LINEAR_OBJECTIVE=>[0,1,1,1,1]);`<br />`$p->LP=$lp;`<br />`$p->LP->MAXIMAL_VALUE;` | `p = @pm Polytopes.Polytope(:POINTS=>Polymake.polytope.cube(4).VERTICES)`<br />`lp = @pm Polytopes.LinearProgram(:LINEAR_OBJECTIVE=>[0,1,1,1,1])`<br />`p.LP = lp`<br />`p.LP.MAXIMAL_VALUE` |
 | `$i = ($p->N_FACETS * $p->N_FACETS) * 15;`                   | `i = (p.N_FACETS * p.N_FACETS) * 15`                         |
+
+### Example script
+
+The following script is modelled on the one from the polymake tutorial:
+
+```julia
+using Polymake
+
+str = read("points.demo", String)
+matrix_str = "["*replace(replace(str, "\n"=>";"), "/"=>"//")*"]"
+matrix = eval(Base.Meta.parse(matrix_str))
+@show matrix
+
+p = @pm Polytopes.Polytope(:POINTS=>matrix)
+
+@show p.FACETS # polymake matrix of polymake rationals
+@show Polymake.polytope.DIM(p) # julias Int64
+# note that even in Polymake property DIM is "fake" -- it's actually a function
+@show p.VERTEX_SIZES # polymake array of ints
+
+for (i, vsize) in enumerate(p.VERTEX_SIZES)
+  if vsize == Polymake.polytope.DIM(p)
+    println("$i : $(p.VERTICES[i,:])")
+    # $i will be shifted by one from the polymake version
+  end
+end
+
+s = [i for (i, vsize) in enumerate(p.VERTEX_SIZES) if vsize == Polymake.polytope.DIM(p)] # julias vector of Int64s
+# note that sets are unordered in julia
+unique!(s)
+
+special_points = p.VERTICES[s, :] # julia Matrix of polymake pationals
+@show special_points
+```
+
+The script included (i.e. in running REPL execute `include("example_script.jl")`) produces the following output:
+```
+matrix = Rational{Int64}[1//1 0//1 0//1 0//1; 1//1 1//16 1//4 1//16; 1//1 3//8 1//4 1//32; 1//1 1//4 3//8 1//32; 1//1 1//16 1//16 1//4; 1//1 1//32 3//8 1//4; 1//1 1//4 1//16 1//16; 1//1 1//32 1//4 3//8; 1//1 3//8 1//32 1//4; 1//1 1//4 1//32 3//8]
+p.FACETS = pm::Matrix<pm::Rational>
+21 -32 -32 -32
+0 20 8 -7
+0 20 -7 8
+0 8 20 -7
+0 20 -1 -1
+0 8 -7 20
+3 16 16 -20
+0 -1 20 -1
+3 16 -20 16
+0 -7 20 8
+0 -7 8 20
+3 -20 16 16
+0 -1 -1 20
+
+(Polymake.polytope).DIM(p) = 3
+p.VERTEX_SIZES = pm::Array<int>
+9 3 4 4 3 4 3 4 4 4
+2 : pm_Rational[1, 1/16, 1/4, 1/16]
+5 : pm_Rational[1, 1/16, 1/16, 1/4]
+7 : pm_Rational[1, 1/4, 1/16, 1/16]
+special_points = pm_Rational[1 1/16 1/4 1/16; 1 1/16 1/16 1/4; 1 1/4 1/16 1/16]
+3×4 Array{pm_Rational,2}:
+ 1  1/16   1/4  1/16
+ 1  1/16  1/16   1/4
+ 1   1/4  1/16  1/16
+```
+As can be seen we show `matrix`, `FACETS`, `DIM` and `VERTEX_SIZES`.
+Then we print rows corresponding to simple vertices and show `special_points`.
+The last ouptut is the return of the `include(...)` function (i.e. the last statement in the `example_script.jl`).
+To suppress it just execute `include("example_script.jl);`.
+
+#### Notes:
+
+The same minor (up to permutation of rows) could be obtained by using sets, or the identical minor by using (ordered) polymake sets.
+Just remember to `collect` the set to a vector when indexing `VERTICES`.
+```julia
+s = Set(i for (i, vsize) in enumerate(p.VERTEX_SIZES) if vsize == Polymake.polytope.DIM(p))
+# s is julias set of Int64s
+
+s = pm_Set(i for (i, vsize) in enumerate(p.VERTEX_SIZES) if vsize == Polymake.polytope.DIM(p))
+# polymake set of longs
+
+special_points = p.VERTICES[collect(s), :]
+```

--- a/deps/parser/parser.jl
+++ b/deps/parser/parser.jl
@@ -161,10 +161,10 @@ export $polymake_app
 end
 
 ## Creates appname_dict
-include( joinpath(@__DIR__,"app_setup.jl" ) )
+include( abspath( joinpath( @__DIR__, "..", "..", "src", "app_setup.jl" ) ) )
 
 for current_file in filenames_list
-    parse_app_definitions(joinpath(jsonfolder,current_file), outputfolder, include_file,additional_json_files_path,appname_dict)
+    parse_app_definitions(joinpath(jsonfolder,current_file), outputfolder, include_file,additional_json_files_path,appname_module_dict)
 end
 
-create_compat_module(outputfolder,include_file,appname_dict)
+create_compat_module(outputfolder,include_file,appname_module_dict)

--- a/src/Polymake.jl
+++ b/src/Polymake.jl
@@ -89,6 +89,7 @@ end
 
 const SmallObject = Union{pm_Integer, pm_Rational, pm_Matrix, pm_Vector, pm_Set, pm_Array}
 
+include("app_setup.jl")
 include("functions.jl")
 include("convert.jl")
 include("object_helpers.jl")

--- a/src/Polymake.jl
+++ b/src/Polymake.jl
@@ -106,6 +106,6 @@ else
     @warn("You need to run '] build Polymake' first.")
 end
 
-enhance_wrapped_type_dict()
+fill_wrapped_types!(WrappedTypes, get_type_names())
 
 end # of module Polymake

--- a/src/app_setup.jl
+++ b/src/app_setup.jl
@@ -1,4 +1,4 @@
-appname_dict = Dict(
+const appname_module_dict = Dict(
   :common  => :Common,
   :fan  => :Fans,
   :fulton  => :Fulton,
@@ -10,3 +10,5 @@ appname_dict = Dict(
   :topaz  => :Topaz,
   :tropical  => :Tropical
 )
+
+const module_appname_dict = Dict( (j,i) for (i,j) in appname_module_dict )

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -31,13 +31,15 @@ const WrappedTypes = Dict(
     Symbol("undefined") => x -> nothing,
 )
 
-function enhance_wrapped_type_dict()
-    name_list = get_type_names()
-    i = 1
-    while i <= length(name_list)
-        WrappedTypes[Symbol(replace(name_list[i+1]," "=>""))] = eval(Symbol(name_list[i]))
-        i += 2
+function fill_wrapped_types!(wrapped_types_dict, function_type_list)
+    function_names = function_type_list[1:2:end]
+    type_names = function_type_list[2:2:end]
+    for (fn, tn) in zip(function_names, type_names)
+        fns = Symbol(fn)
+        tn = replace(tn," "=>"")
+        @eval $wrapped_types_dict[Symbol($tn)] = Polymake.$fns
     end
+    return wrapped_types_dict
 end
 
 Base.propertynames(p::Polymake.pm_perl_Object) = Symbol.(Polymake.complete_property(p, ""))

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -88,7 +88,11 @@ end
 
 Base.propertynames(p::Polymake.pm_perl_Object) = Symbol.(Polymake.complete_property(p, ""))
 
-function Base.setproperty!(obj::pm_perl_Object, prop::Union{Symbol,String}, val)
+function Base.setproperty!(obj::pm_perl_Object, prop::String, val)
+    return take(obj, prop, convert_to_pm(val))
+end
+
+function Base.setproperty!(obj::pm_perl_Object, prop::Symbol, val)
     return take(obj, string(prop), convert_to_pm(val))
 end
 

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -23,19 +23,6 @@ function perlobj(name::String, input_data::Pair{<:Union{Symbol,String}}...; kwar
     return obj
 end
 
-const module_appname_dict = Dict(
-  :Common  => :common,
-  :Fans  => :fan,
-  :Fulton  => :fulton,
-  :Graphs  => :graph,
-  :Groups  => :group,
-  :Ideals  => :ideal,
-  :Matroids  => :matroid,
-  :Polytopes  => :polytope,
-  :Topaz  => :topaz,
-  :Tropical  => :tropical
-)
-
 function qualified_func_name(app_name, func_name, template_params=Symbol[])
     name = "$app_name::$func_name"
     if length(template_params) > 0

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -36,7 +36,7 @@ const module_appname_dict = Dict(
   :Tropical  => :tropical
 )
 
-function qualified_func_name(app_name, func_name, template_params=:Symbol[])
+function qualified_func_name(app_name, func_name, template_params=Symbol[])
     name = "$app_name::$func_name"
     if length(template_params) > 0
         name *= "<$(join(template_params, ","))>"

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -12,13 +12,13 @@ function perlobj(name::String, input_data::Dict{<:Union{String, Symbol},T}) wher
     return perl_obj
 end
 
-function perlobj(name::String, input_data::Pair{Symbol}...; kwargsdata...)
+function perlobj(name::String, input_data::Pair{<:Union{Symbol,String}}...; kwargsdata...)
     obj = pm_perl_Object(name)
     for (key, val) in input_data
-        setproperty!(obj, key, val)
+        setproperty!(obj, string(key), val)
     end
     for (key, val) in kwargsdata
-        setproperty!(obj, key, val)
+        setproperty!(obj, string(key), val)
     end
     return obj
 end
@@ -42,8 +42,8 @@ end
 
 Base.propertynames(p::Polymake.pm_perl_Object) = Symbol.(Polymake.complete_property(p, ""))
 
-function Base.setproperty!(obj::pm_perl_Object, prop::Symbol, val)
-    take(obj, string(prop), convert_to_pm(val))
+function Base.setproperty!(obj::pm_perl_Object, prop::Union{Symbol,String}, val)
+    return take(obj, string(prop), convert_to_pm(val))
 end
 
 struct Visual

--- a/test/perlobj.jl
+++ b/test/perlobj.jl
@@ -4,45 +4,54 @@
     input_dict_unbounded = Dict("POINTS" => [1 0 0; 0 1 1])
 
     @testset "constructors" begin
-        @test perlobj("Polytope", input_dict_int ) isa pm_perl_Object
-        @test perlobj("Polytope", input_dict_rat ) isa pm_perl_Object
-        @test perlobj("Polytope",
+        @test Polymake.perlobj("polytope::Polytope", input_dict_int ) isa pm_perl_Object
+        @test Polymake.perlobj("polytope::Polytope", input_dict_rat ) isa pm_perl_Object
+        @test Polymake.perlobj("polytope::Polytope",
             POINTS=[ 1 0 0 ; 1 3 0 ; 1 0 3 ; 1 3 3 ]) isa pm_perl_Object
-        @test perlobj("Polytope",
+        @test Polymake.perlobj("polytope::Polytope",
             :POINTS => [ 1 0 0 ; 1 3 0 ; 1 0 3 ; 1 3 3 ]) isa pm_perl_Object
+
+        @test (@pm Polytopes.Polytope(input_dict_int)) isa pm_perl_Object
+        @test (@pm Polytopes.Polytope(input_dict_rat)) isa pm_perl_Object
+        @test (@pm Polytopes.Polytope(POINTS=[ 1 0 0 ; 1 3 0 ; 1 0 3 ; 1 3 3 ])) isa pm_perl_Object
+        @test (@pm Polytopes.Polytope(:POINTS=>[ 1 0 0 ; 1 3 0 ; 1 0 3 ; 1 3 3 ])) isa pm_perl_Object
+        @test (@pm Polytopes.Polytope("POINTS"=>[ 1 0 0 ; 1 3 0 ; 1 0 3 ; 1 3 3 ])) isa pm_perl_Object
+
+        @test (@pm Tropical.Polytope{Max}(input_dict_int)) isa pm_perl_Object
+
+        @test (@pm Tropical.Polytope{Max}(input_dict_int)) isa pm_perl_Object
+        @test (@pm Tropical.Polytope{Max, Rational}(input_dict_int)) isa pm_perl_Object
     end
 
-    @testset "output" begin
-        test_polytope = perlobj("Polytope", input_dict_int )
+    @testset "PolymakeException" begin
+        test_polytope = @pm Polytopes.Polytope(input_dict_int)
+        @test !(:STH in Base.propertynames(test_polytope))
+        @test_throws PolymakeError test_polytope.STH
+    end
+
+    @testset "properties" begin
+        test_polytope = @pm Polytopes.Polytope(input_dict_int)
         @test test_polytope.F_VECTOR == [ 4, 4 ]
         @test test_polytope.INTERIOR_LATTICE_POINTS ==
             [ 1 1 1 ; 1 1 2 ; 1 2 1 ; 1 2 2 ]
-    end
-    
-    @testset "PolymakeException" begin
-        test_polytope = perlobj("Polytope", input_dict_int )
-        @test !(:STH in Base.propertynames(test_polytope))
-        @test_throws PolymakeError test_polytope.STH
+
         @test test_polytope.GRAPH isa pm_perl_Object
         test_graph = test_polytope.GRAPH
         @test :ADJACENCY in Base.propertynames(test_graph)
         @test_logs (:warn, "The return value contains pm::graph::Graph<pm::graph::Undirected> which has not been wrapped yet") test_graph.ADJACENCY isa Polymake.pm_perl_PropertyValue
-    end
-    
-    @testset "lattice points" begin
-        test_polytope = perlobj("Polytope", input_dict_int )
+
         @test test_polytope.LATTICE_POINTS_GENERATORS isa pm_Array
-        
-        test_polytope = perlobj("Polytope", input_dict_unbounded )
+
+        test_polytope = @pm Polytopes.Polytope(input_dict_unbounded)
         @test test_polytope.FAR_FACE == Set([1])
     end
-    
+
     @testset "tab-completion" begin
-        test_polytope = perlobj("Polytope", input_dict_int )
-        
+        test_polytope = @pm Polytopes.Polytope(input_dict_int)
+
         @test Base.propertynames(test_polytope) isa Vector{Symbol}
         names = Base.propertynames(test_polytope)
-        
+
         @test :VERTICES in names
         @test :FAR_FACE in names
         @test :GRAPH in names
@@ -53,7 +62,7 @@
     end
 
     @testset "save load" begin
-        test_polytope = perlobj("Polytope", input_dict_rat )
+        test_polytope = @pm Polytopes.Polytope(input_dict_int)
         mktempdir() do path
             Polymake.save_perl_object(test_polytope,joinpath(path,"test.poly"))
             loaded = Polymake.load_perl_object(joinpath(path,"test.poly"))

--- a/test/perlobj.jl
+++ b/test/perlobj.jl
@@ -12,7 +12,11 @@
             :POINTS => [ 1 0 0 ; 1 3 0 ; 1 0 3 ; 1 3 3 ]) isa pm_perl_Object
 
         @test (@pm Polytopes.Polytope(input_dict_int)) isa pm_perl_Object
+        @test (@pm Polytopes.Polytope{Rational}(input_dict_int)) isa pm_perl_Object
+        @test (@pm Polytopes.Polytope{QuadraticExtension}(input_dict_int)) isa pm_perl_Object
+
         @test (@pm Polytopes.Polytope(input_dict_rat)) isa pm_perl_Object
+
         @test (@pm Polytopes.Polytope(POINTS=[ 1 0 0 ; 1 3 0 ; 1 0 3 ; 1 3 3 ])) isa pm_perl_Object
         @test (@pm Polytopes.Polytope(:POINTS=>[ 1 0 0 ; 1 3 0 ; 1 0 3 ; 1 3 3 ])) isa pm_perl_Object
         @test (@pm Polytopes.Polytope("POINTS"=>[ 1 0 0 ; 1 3 0 ; 1 0 3 ; 1 3 3 ])) isa pm_perl_Object
@@ -21,6 +25,7 @@
 
         @test (@pm Tropical.Polytope{Max}(input_dict_int)) isa pm_perl_Object
         @test (@pm Tropical.Polytope{Max, Rational}(input_dict_int)) isa pm_perl_Object
+        @test (@pm Tropical.Polytope{Max, QuadraticExtension}(input_dict_int)) isa pm_perl_Object
     end
 
     @testset "PolymakeException" begin
@@ -69,5 +74,49 @@
             @test loaded isa pm_perl_Object
             @test Base.propertynames(test_polytope) == Base.propertynames(loaded)
         end
+    end
+
+    @testset "polymake tutorials" begin
+        p = @pm Polytopes.Polytope(:POINTS=>Polymake.Polytopes.cube(4).VERTICES)
+        @test p isa pm_perl_Object
+
+        lp = @pm Polytopes.LinearProgram(:LINEAR_OBJECTIVE=>[0,1,1,1,1])
+        @test lp isa pm_perl_Object
+
+        @test (p.LP = lp) isa pm_perl_Object
+        @test p.LP.MAXIMAL_VALUE == 4
+
+        matrix = Rational{Int64}[
+            1//1  0//1  0//1  0//1;
+            1//1  1//16 1//4  1//16;
+            1//1  3//8  1//4  1//32;
+            1//1  1//4  3//8  1//32;
+            1//1  1//16 1//16 1//4;
+            1//1  1//32 3//8  1//4;
+            1//1  1//4  1//16 1//16;
+            1//1  1//32 1//4  3//8;
+            1//1  3//8  1//32 1//4;
+            1//1  1//4  1//32 3//8]
+
+        special_points = pm_Rational[
+            1 1//16 1//4 1//16;
+            1 1//16 1//16 1//4;
+            1 1//4 1//16 1//16]
+
+        p = @pm Polytopes.Polytope(:POINTS=>matrix)
+
+        @test Polymake.Polytopes.DIM(p) == 3
+
+        @test p.VERTEX_SIZES == [9, 3, 4, 4, 3, 4, 3, 4, 4, 4]
+
+        s = Set(i for (i, vsize) in enumerate(p.VERTEX_SIZES)
+                if vsize == Polymake.Polytopes.DIM(p))
+        pm_s = pm_Set(i for (i, vsize) in enumerate(p.VERTEX_SIZES)
+                if vsize == Polymake.Polytopes.DIM(p))
+
+        @test Set([2,5,7]) == s == pm_s
+
+        @test p.VERTICES[collect(pm_s), :] isa Matrix{pm_Rational}
+        @test p.VERTICES[collect(pm_s), :] == special_points
     end
 end


### PR DESCRIPTION
adds @pm macro, e.g.
`@pm Polytopes.Polytope{QuadraticExtension}(POINTS=...)`
constructs the polytope without `Polymake.jl` having to worry about `QuardaticExtension`s.

functionname has to fully specified;

@saschatimme please have a look at macro
@sebasguts this also changes the way WrappedTypes dictionary is filled (this has been sitting in my branch for quite some time).