### PR TITLE
 Make it possible to pass other AbstractVectors / AbstractMatrices

### DIFF
--- a/src/convert.jl
+++ b/src/convert.jl
@@ -85,6 +85,11 @@ end
 convert_to_pm(x) = x
 convert_to_pm(x::T) where T <:Integer = Base.convert(pm_Integer,x)
 convert_to_pm(x::Rational{T}) where T <:Integer = Base.convert(pm_Rational,x)
+# We realize AbstractVectors/Matrices if they are not already Vector/Matrix or pm_*
+convert_to_pm(x::AbstractVector) = convert_to_pm(Vector(x))
+convert_to_pm(x::AbstractMatrix) = convert_to_pm(Matrix(x))
+convert_to_pm(x::pm_Vector) = x
+convert_to_pm(x::pm_Matrix) = x
 convert_to_pm(x::Array{T,1}) where T <:Integer = Base.convert(pm_Vector{pm_Integer},x)
 convert_to_pm(x::Array{Rational{T},1}) where T <:Integer = Base.convert(pm_Vector{pm_Rational},x)
 convert_to_pm(x::Array{T,2}) where T <:Integer = Base.convert(pm_Matrix{pm_Integer},x)

--- a/test/perlobj.jl
+++ b/test/perlobj.jl
@@ -6,14 +6,14 @@
     @testset "constructors" begin
         @test Polymake.perlobj("polytope::Polytope", input_dict_int ) isa pm_perl_Object
         @test Polymake.perlobj("polytope::Polytope", input_dict_rat ) isa pm_perl_Object
-        @test Polymake.perlobj("polytope::Polytope",
-            POINTS=[ 1 0 0 ; 1 3 0 ; 1 0 3 ; 1 3 3 ]) isa pm_perl_Object
-        @test Polymake.perlobj("polytope::Polytope",
-            :POINTS => [ 1 0 0 ; 1 3 0 ; 1 0 3 ; 1 3 3 ]) isa pm_perl_Object
+        A = [ 1 0 0 ; 1 3 0 ; 1 0 3 ; 1 3 3 ]
+        @test Polymake.perlobj("polytope::Polytope", POINTS=A) isa pm_perl_Object
+        @test Polymake.perlobj("polytope::Polytope", :POINTS => A) isa pm_perl_Object
         # macro literals
-        @test (@pm Polytopes.Polytope(POINTS=[ 1 0 0 ; 1 3 0 ; 1 0 3 ; 1 3 3 ])) isa pm_perl_Object
-        @test (@pm Polytopes.Polytope(:POINTS=>[ 1 0 0 ; 1 3 0 ; 1 0 3 ; 1 3 3 ])) isa pm_perl_Object
-        @test (@pm Polytopes.Polytope("POINTS"=>[ 1 0 0 ; 1 3 0 ; 1 0 3 ; 1 3 3 ])) isa pm_perl_Object
+        @test (@pm Polytopes.Polytope(POINTS=A)) isa pm_perl_Object
+        @test (@pm Polytopes.Polytope(POINTS=A)) isa pm_perl_Object
+        @test (@pm Polytopes.Polytope(:POINTS => A)) isa pm_perl_Object
+        @test (@pm Polytopes.Polytope("POINTS" => A)) isa pm_perl_Object
 
         # make sure we're escaping where we should
         @test (@pm Polytopes.Polytope(input_dict_int)) isa pm_perl_Object
@@ -27,11 +27,14 @@
         @test (@pm Tropical.Polytope{Max}(input_dict_int)) isa pm_perl_Object
         @test (@pm Tropical.Polytope{Max, Rational}(input_dict_int)) isa pm_perl_Object
         @test (@pm Tropical.Polytope{Max, QuadraticExtension}(input_dict_int)) isa pm_perl_Object
-        
+
         @test (@pm Tropical.Hypersurface{Min}(
             MONOMIALS=[1 0 0; 0 1 0; 0 0 1],
             COEFFICIENTS=[0, 0, 0])) isa pm_perl_Object
         # note: You need to input COEFFICIENTS as Vector, otherwise it will be converted to pm_Matrix which polymake doesn't like.
+
+        # Make sure that we can also handle different matrix types, e.g. adjoint
+        @test (@pm Polytopes.Polytope(POINTS=A')) isa pm_perl_Object
     end
 
     @testset "PolymakeException" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,15 +1,11 @@
 using Polymake
-@static if VERSION < v"0.7.0-DEV.2005"
-    using Base.Test
-else
-    using Test
-end
+using Test
 
 # write your own tests here
 @testset "Polymake" begin
-    
+
     Polymake.@register Polytopes.pseudopower
-    
+
     include("integers.jl")
     include("rationals.jl")
     include("vectors.jl")


### PR DESCRIPTION
I noticed that we couldn't handle matrix types besides `Matrix` and `pm_Matrix`, in particular we couldn't work with the lazy wrappers for matrices. These occur for example for the transpose of a matrix.

```
julia> A = [1 2; 3 4; 5 6]
3×2 Array{Int64,2}:
 1  2
 3  4
 5  6

julia> A'
2×3 LinearAlgebra.Adjoint{Int64,Array{Int64,2}}:
 1  3  5
 2  4  6
```

I fixed this by converting any `AbstractMatrix` to `Matrix` in `convert_to_pm`.

On the way I also added two small fixes. 