### PR TITLE
Update REQUIRE File (and drop Julia 0.7)

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,7 +1,6 @@
-julia 0.7
+julia 1.0
+BinaryProvider
+CMake
 CxxWrap
 JSON
-REPL
-Pkg
-BinaryProvider
 Libdl


### PR DESCRIPTION
* In the REQUIRE file we only need non standard library dependencies.
* Supporting Julia 0.7 is rather pointless by now.