### PR TITLE
remove MbedTLS workaround from travis script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,3 @@ addons:
     packages:
     - gcc-7
     - g++-7
-before_script:
-  - julia -e 'using Pkg;
-    Pkg.add(PackageSpec(name="MbedTLS", version="0.6.6"));
-    Pkg.pin(PackageSpec(name="MbedTLS", version="0.6.6"));'


### PR DESCRIPTION
should be ok with latest mbedtls 0.6.8