### PR TITLE
remove superfluous return from @pm macro

### DIFF
--- a/src/functions.jl
+++ b/src/functions.jl
@@ -183,7 +183,7 @@ POINTS
 
 
 ```
-Note: the expression in `@pm` macro is parsed syntactically, so it has to be a valid `julia` expression. However template parameters NEED NOT to be defined in `julia`, but must be valid names of `polymake` property types.
+Note: the expression in `@pm` macro is parsed syntactically, so it has to be a valid `julia` expression. However template parameters NEED NOT to be defined in `julia`, but must be valid names of `polymake` property types. Nested types (such as `{QuadraticExtension{Rational}}`) are allowed.
 """
 macro pm(expr)
     module_name, polymake_func, templates, args, kwargs = Meta.parse_function_call(expr)

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -183,7 +183,7 @@ POINTS
 
 
 ```
-Note: the expression in `@pm` macro is parsed syntactically, so it has to be a valid `julia` expression. However template parameters NEED NOT to be defined in `julia`, but must be valid names of `polymake` property types. Nested types (such as `{QuadraticExtension{Rational}}`) are allowed.
+Note: the expression in `@pm` macro is parsed syntactically, so it has to be a valid `julia` expression. However template parameters **need not** to be defined in `julia`, but must be valid names of `polymake` property types. Nested types (such as `{QuadraticExtension{Rational}}`) are allowed.
 """
 macro pm(expr)
     module_name, polymake_func, templates, args, kwargs = Meta.parse_function_call(expr)

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -139,6 +139,52 @@ end
 
 Base.getproperty(obj::pm_perl_Object, prop::Symbol) = give(obj, string(prop))
 
+
+"""
+    @pm PolymakeModule.function_name{Template, parameters}(args)
+
+This macro can be used to
+ * create `polymake` Big Objects (such as polytopes)
+ * call `polymake` functions with specific template parameters.
+
+The expression passed to the macro has to be fully qualified name (starting with the uppercase name of polymake application) of a `polymake` object or function, with template parameters enclosed in `{ ... }`.
+
+# Examples
+```jldoctest
+julia> P = @pm Polytope.Polytope{QuadraticExtension}(POINTS=[1 0 0; 0 1 0])
+type: Polytope<QuadraticExtension<Rational>>
+
+POINTS
+1 0 0
+0 1 0
+
+
+
+julia> @pm Common.convert_to{Float}(P)
+type: Polytope<Float>
+
+POINTS
+1 0 0
+0 1 0
+
+
+CONE_AMBIENT_DIM
+3
+
+
+
+julia> @pm Tropical.Polytope{Max}(POINTS=[1 0 0; 0 1 0])
+type: Polytope<Max, Rational>
+
+POINTS
+0 -1 -1
+0 1 0
+
+
+
+```
+Note: the expression in `@pm` macro is parsed syntactically, so it has to be a valid `julia` expression. However template parameters NEED NOT to be defined in `julia`, but must be valid names of `polymake` property types.
+"""
 macro pm(expr)
     module_name, polymake_func, templates, args, kwargs = Meta.parse_function_call(expr)
     polymake_app = Meta.get_polymake_app_name(module_name)

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -147,7 +147,7 @@ This macro can be used to
  * create `polymake` Big Objects (such as polytopes)
  * call `polymake` functions with specific template parameters.
 
-The expression passed to the macro has to be fully qualified name (starting with the uppercase name of polymake application) of a `polymake` object or function, with template parameters enclosed in `{ ... }`.
+The expression passed to the macro has to be the fully qualified name (starting with the uppercase name of polymake application) of a `polymake` object or function, with template parameters enclosed in `{ ... }`.
 
 # Examples
 ```jldoctest

--- a/src/meta.jl
+++ b/src/meta.jl
@@ -23,6 +23,14 @@ end
 
 ############### macro helpers
 
+function recursive_replace(s::Symbol, pairs::Dict)
+    str = string(s)
+    for (p,r) in pairs
+        str = replace(str, p=>r)
+    end
+    return Symbol(str)
+end
+
 function parse_function_call(expr)
     @assert expr.head == :call
     func = expr.args[1] # called function
@@ -31,8 +39,10 @@ function parse_function_call(expr)
     templates = Symbol[]
     # grab template parameters if present
     if func.head == :curly
-        templates = func.args[2:end]
+        templates = Symbol.(func.args[2:end])
         func = func.args[1]
+
+        templates = recursive_replace.(templates, Ref(Dict("{"=>"<", "}"=>">")))
     end
 
     @assert func.head == Symbol('.')

--- a/test/perlobj.jl
+++ b/test/perlobj.jl
@@ -18,6 +18,7 @@
         @test (@pm Polytope.Polytope(input_dict_int)) isa pm_perl_Object
         @test (@pm Polytope.Polytope{Rational}(input_dict_int)) isa pm_perl_Object
         @test (@pm Polytope.Polytope{QuadraticExtension}(input_dict_int)) isa pm_perl_Object
+        @test (@pm Polytope.Polytope{QuadraticExtension{Rational}}(input_dict_int)) isa pm_perl_Object
 
         @test (@pm Polytope.Polytope(input_dict_rat)) isa pm_perl_Object
 


### PR DESCRIPTION
the return statement was causing returns from functions in "unexpected" places (i.e. right after application of `@pm` :P