### PR TITLE
Remove warning for doc string syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,9 +294,6 @@ For example:
 julia> c = Polytope.cube(3);
 
 julia> f = c.FACETS;
-┌ Warning: The return value contains pm::SparseMatrix<pm::Rational, pm::NonSymmetric> which has not been wrapped yet;
-│ use `@pm Common.convert_to{wrapped_type}(...)` to convert to julia-understandable type.
-└ @ Polymake ~/.julia/dev/Polymake/src/functions.jl:66
 
 julia> f[1,1] # f is an opaque pm::perl::PropertyValue to julia
 ERROR: MethodError: no method matching getindex(::Polymake.pm_perl_PropertyValueAllocated, ::Int64, ::Int64)

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -61,9 +61,6 @@ function convert_from_property_value(obj::Polymake.pm_perl_PropertyValue)
     elseif startswith(type_name,"Visual::")
         return Visual(obj)
     else
-        lines = ["The return value contains $type_name which has not been wrapped yet;",
-        "use `@pm Common.convert_to{wrapped_type}(...)` to convert to julia-understandable type."]
-        @warn(join(lines, "\n"))
         return obj
     end
 end

--- a/src/meta.jl
+++ b/src/meta.jl
@@ -194,10 +194,8 @@ function jl_code(pf::PolymakeFunction)
             end
         end;
         function $(Base.Docs).getdoc(::typeof($(jl_symbol(pf))))
-            @warn "Below is the Polymake syntax.\nPlease refer to the Polymake.jl Readme for a translation guide"
             docstrs = get_docs($func_name, full=true)
-            sep = "---"
-            return Markdown.parse(join(docstrs, "\n\n$sep\n\n"))
+            return Markdown.parse(join(docstrs, "\n\n---\n\n"))
         end;
         export $(jl_symbol(pf));
     )

--- a/test/perlobj.jl
+++ b/test/perlobj.jl
@@ -79,8 +79,6 @@
         @test test_polytope.GRAPH isa pm_perl_Object
         test_graph = test_polytope.GRAPH
         @test :ADJACENCY in Base.propertynames(test_graph)
-        @test_logs (:warn, "The return value contains pm::graph::Graph<pm::graph::Undirected> which has not been wrapped yet;
-use `@pm Common.convert_to{wrapped_type}(...)` to convert to julia-understandable type.") test_graph.ADJACENCY isa Polymake.pm_perl_PropertyValue
 
         @test test_polytope.LATTICE_POINTS_GENERATORS isa pm_Array
 


### PR DESCRIPTION
This warning doesn't work well with IDEs (e.g. Atom) since they query for the docstring for every function  in the background. Also I think this becomes quite annoying after the 3rd use.
This PR just removes this warning completely, I think it its obvious that the doc strings are not in Julia syntax...