### PR TITLE
Fix mismatch between pm_array cpp and pm_Array_suppT

### DIFF
--- a/deps/src/polymake_arrays.cpp
+++ b/deps/src/polymake_arrays.cpp
@@ -14,8 +14,10 @@ void polymake_module_add_array(jlcxx::Module& polymake)
         .add_type<jlcxx::Parametric<jlcxx::TypeVar<1>>>(
             "pm_Array", jlcxx::julia_type("AbstractVector", "Base"))
         .apply<pm::Array<int32_t>, pm::Array<long>, pm::Array<pm::Integer>,
+               pm::Array<pm::Rational>,
                pm::Array<std::string>, pm::Array<pm::Set<int32_t>>,
-               pm::Array<pm::Array<int32_t>>, pm::Array<pm::Array<long>>,
+               pm::Array<pm::Array<int32_t>>,
+               pm::Array<pm::Array<long>>,
                pm::Array<pm::Array<pm::Integer>>,
                pm::Array<pm::Matrix<pm::Integer>>>([](auto wrapped) {
             typedef typename decltype(wrapped)::type             WrappedT;

--- a/src/arrays.jl
+++ b/src/arrays.jl
@@ -1,4 +1,7 @@
-const pm_Array_suppT = Union{Int32, Int64, String, pm_Set{Int32}, pm_Matrix{pm_Integer}, AbstractString}
+const pm_Array_suppT = Union{Int32, Int64, pm_Integer,
+                      String, AbstractString, pm_Set{Int32},
+                      pm_Array{Int32}, pm_Array{Int64}, pm_Array{pm_Integer},
+                      pm_Matrix{pm_Integer}}
 
 function pm_Array{T}(vec::AbstractVector) where T <: pm_Array_suppT
     arr = pm_Array{T}(length(vec))

--- a/src/arrays.jl
+++ b/src/arrays.jl
@@ -1,4 +1,4 @@
-const pm_Array_suppT = Union{Int32, Int64, pm_Integer,
+const pm_Array_suppT = Union{Int32, Int64, pm_Integer, pm_Rational,
                       String, AbstractString, pm_Set{Int32},
                       pm_Array{Int32}, pm_Array{Int64}, pm_Array{pm_Integer},
                       pm_Matrix{pm_Integer}}

--- a/test/arrays.jl
+++ b/test/arrays.jl
@@ -1,10 +1,15 @@
 @testset "pm_Array" begin
     @testset "pm_Array generics: $T " for (T, elt) in [
-        (Int32, 2), 
+        (Int32, 2),
         (Int64, 2),
+        (pm_Integer, pm_Integer(2)),
+        (pm_Rational, pm_Rational(2 //3)),
         (AbstractString, "a"),
-        (pm_Set{Int32}, pm_Set{Int32}([1,2,1])), 
+        (pm_Set{Int32}, pm_Set{Int32}([1,2,1])),
         (pm_Matrix{pm_Integer}, pm_Matrix{pm_Integer}([1 0; 2 1])),
+        (pm_Array{Int32}, pm_Array{Int32}(Int32[1, 2, 3])),
+        (pm_Array{Int64}, pm_Array{Int64}(Int64[1, 2, 3])),
+        (pm_Array{pm_Integer}, pm_Array{pm_Integer}(pm_Integer[1, 2, 3])),
         ]
         @test pm_Array{T} <: AbstractVector
         @test pm_Array{T}(3) isa AbstractVector


### PR DESCRIPTION
I noticed that we declared much less `pm_Array` element types on the Julia site than on the cpp side.

Who do I have to bribe to not write all the missing tests? 😅 