### PR TITLE
add solve_LP

### DIFF
--- a/deps/src/polymake.cpp
+++ b/deps/src/polymake.cpp
@@ -20,6 +20,8 @@
 
 #include "polymake_caller.h"
 
+#include "polymake_direct_calls.h"
+
 #include "polymake_type_translations.h"
 
 #include "generated/type_declarations.h"
@@ -41,6 +43,8 @@ JLCXX_MODULE define_module_polymake(jlcxx::Module& polymake)
     polymake_module_add_set(polymake);
 
     polymake_module_add_array(polymake);
+
+    polymake_module_add_direct_calls(polymake);
 
     polymake.method("initialize_polymake", &initialize_polymake);
     polymake.method("application", [](const std::string x) {

--- a/deps/src/polymake.cpp
+++ b/deps/src/polymake.cpp
@@ -48,16 +48,7 @@ JLCXX_MODULE define_module_polymake(jlcxx::Module& polymake)
     });
 
     polymake.method("shell_execute", [](const std::string x) {
-        // FIXME: tuples with strings are broken in cxxwrap
-        // return res;
-        // instead we return an array of a bool and three strings now
-        auto         res = data.main_polymake_session->shell_execute(x);
-        jl_value_t** output = new jl_value_t*[4];
-        output[0] = jl_box_bool(std::get<0>(res));
-        output[1] = jl_cstr_to_string(std::get<1>(res).c_str());
-        output[2] = jl_cstr_to_string(std::get<2>(res).c_str());
-        output[3] = jl_cstr_to_string(std::get<3>(res).c_str());
-        return jlcxx::make_julia_array(output, 4);
+        return data.main_polymake_session->shell_execute(x);
     });
 
     polymake.method("shell_complete", [](const std::string x) {
@@ -75,10 +66,7 @@ JLCXX_MODULE define_module_polymake(jlcxx::Module& polymake)
         bool full=false, bool html=false){
         std::vector<std::string> ctx_help =
             data.main_polymake_session->shell_context_help(input, pos, full, html);
-        jl_value_t** doc_strings = new jl_value_t*[ctx_help.size()];
-        for (int i=0; i < ctx_help.size(); ++i)
-            doc_strings[i] = jl_cstr_to_string(ctx_help[i].c_str());
-        return jlcxx::make_julia_array(doc_strings, ctx_help.size());
+        return jlcxx::make_julia_array(&ctx_help[0], ctx_help.size());
     });
 
 #include "generated/map_inserts.h"

--- a/deps/src/polymake_direct_calls.cpp
+++ b/deps/src/polymake_direct_calls.cpp
@@ -2,37 +2,24 @@
 
 #include "polymake_direct_calls.h"
 
-auto direct_call_solve_LP(
-    const pm::Matrix<pm::Rational>& inequalities,
-    const pm::Matrix<pm::Rational>& equalities,
-    const pm::Vector<pm::Rational>& objective,
-    bool                            maximize)
-{
-    try {
-        auto solution = polymake::polytope::solve_LP(inequalities, equalities, objective, maximize);
-        return solution.solution;
-    } catch (...) {
-        return pm::Vector<pm::Rational>();
-    }
-}
-
-auto direct_call_solve_LP_float(
-    const pm::Matrix<double>& inequalities,
-    const pm::Matrix<double>& equalities,
-    const pm::Vector<double>& objective,
+template<typename Scalar>
+pm::Vector<Scalar> direct_call_solve_LP(
+    const pm::Matrix<Scalar>& inequalities,
+    const pm::Matrix<Scalar>& equalities,
+    const pm::Vector<Scalar>& objective,
     bool                      maximize)
 {
     try {
         auto solution = polymake::polytope::solve_LP(inequalities, equalities, objective, maximize);
         return solution.solution;
     } catch (...) {
-        return pm::Vector<double>();
+        return pm::Vector<Scalar>();
     }
 }
 
 
 void polymake_module_add_direct_calls(jlcxx::Module& polymake)
 {
-    polymake.method("direct_call_solve_LP", &direct_call_solve_LP);
-    polymake.method("direct_call_solve_LP_float", &direct_call_solve_LP_float);
+    polymake.method("direct_call_solve_LP", &direct_call_solve_LP<pm::Rational>);
+    polymake.method("direct_call_solve_LP_float", &direct_call_solve_LP<double>);
 }

--- a/deps/src/polymake_direct_calls.cpp
+++ b/deps/src/polymake_direct_calls.cpp
@@ -1,0 +1,38 @@
+#include "polymake_includes.h"
+
+#include "polymake_direct_calls.h"
+
+auto direct_call_solve_LP(
+    const pm::Matrix<pm::Rational>& inequalities,
+    const pm::Matrix<pm::Rational>& equalities,
+    const pm::Vector<pm::Rational>& objective,
+    bool                            maximize)
+{
+    try {
+        auto solution = polymake::polytope::solve_LP(inequalities, equalities, objective, maximize);
+        return solution.solution;
+    } catch (...) {
+        return pm::Vector<pm::Rational>();
+    }
+}
+
+auto direct_call_solve_LP_float(
+    const pm::Matrix<double>& inequalities,
+    const pm::Matrix<double>& equalities,
+    const pm::Vector<double>& objective,
+    bool                      maximize)
+{
+    try {
+        auto solution = polymake::polytope::solve_LP(inequalities, equalities, objective, maximize);
+        return solution.solution;
+    } catch (...) {
+        return pm::Vector<double>();
+    }
+}
+
+
+void polymake_module_add_direct_calls(jlcxx::Module& polymake)
+{
+    polymake.method("direct_call_solve_LP", &direct_call_solve_LP);
+    polymake.method("direct_call_solve_LP_float", &direct_call_solve_LP_float);
+}

--- a/deps/src/polymake_direct_calls.h
+++ b/deps/src/polymake_direct_calls.h
@@ -1,0 +1,8 @@
+#ifndef POLYMAKE_DIRECT_CALLS
+#define POLYMAKE_DIRECT_CALLS
+
+#include "jlcxx/jlcxx.hpp"
+
+void polymake_module_add_direct_calls(jlcxx::Module&);
+
+#endif

--- a/deps/src/polymake_includes.h
+++ b/deps/src/polymake_includes.h
@@ -18,6 +18,7 @@
 #include <polymake/IncidenceMatrix.h>
 #include <polymake/Rational.h>
 #include <polymake/QuadraticExtension.h>
+#include <polymake/polytope/solve_LP.h>
 
 #include <polymake/perl/calls.h>
 

--- a/src/Polymake.jl
+++ b/src/Polymake.jl
@@ -92,8 +92,6 @@ include("perlobj.jl")
 include("visual.jl")
 include("convert.jl")
 
-include("generate_applications.jl")
-
 include("integers.jl")
 include("rationals.jl")
 include("sets.jl")
@@ -102,4 +100,7 @@ include("matrices.jl")
 include("broadcast.jl")
 include("arrays.jl")
 
+include("polymake_direct_calls.jl")
+
+include("generate_applications.jl")
 end # of module Polymake

--- a/src/polymake_direct_calls.jl
+++ b/src/polymake_direct_calls.jl
@@ -1,0 +1,35 @@
+const AbstractRational = Union{Rational, pm_Rational}
+
+for (m, flag) in [(:min, false), (:max, true)]
+    @eval begin
+        function solve_LP(
+            inequalities::AbstractMatrix{<:AbstractRational},
+            equalities::AbstractMatrix{<:AbstractRational},
+            objective::AbstractVector{<:AbstractRational}, ::typeof($m))
+
+            return direct_call_solve_LP(
+                convert(pm_Matrix{pm_Rational}, inequalities),
+                convert(pm_Matrix{pm_Rational}, equalities),
+                convert(pm_Vector{pm_Rational}, objective),
+                $flag
+            )
+        end
+
+        function solve_LP(
+            inequalities::AbstractMatrix{<:AbstractFloat},
+            equalities::AbstractMatrix{<:AbstractFloat},
+            objective::AbstractVector{<:AbstractFloat}, ::typeof($m))
+
+            return direct_call_solve_LP_float(
+                convert(pm_Matrix{Float64}, inequalities),
+                convert(pm_Matrix{Float64}, equalities),
+                convert(pm_Vector{Float64}, objective),
+                $flag
+            )
+        end
+    end
+end
+
+solve_LP(inequalities::AbstractMatrix{T}, objective::AbstractVector; sense=max) where T = solve_LP(inequalities, Matrix{T}(undef, 0, 0), objective, sense)
+
+solve_LP(inequalities::AbstractMatrix, equalities::AbstractMatrix, objective::AbstractVector; sense=max) = solve_LP(inequalities, equalities, objective, sense)

--- a/src/polymake_direct_calls.jl
+++ b/src/polymake_direct_calls.jl
@@ -1,31 +1,24 @@
 const AbstractRational = Union{Rational, pm_Rational}
 
-for (m, flag) in [(:min, false), (:max, true)]
-    @eval begin
-        function solve_LP(
-            inequalities::AbstractMatrix{<:AbstractRational},
-            equalities::AbstractMatrix{<:AbstractRational},
-            objective::AbstractVector{<:AbstractRational}, ::typeof($m))
+for (pm_solve_LP, scalarT, concreteT) in [
+    (:direct_call_solve_LP, AbstractRational, pm_Rational),
+    (:direct_call_solve_LP_float, AbstractFloat, Float64),
+    ]
+    for (m, flag) in [(:min, false), (:max, true)]
+        @eval begin
+            function solve_LP(
+                inequalities::AbstractMatrix{<:$scalarT},
+                equalities::AbstractMatrix{<:$scalarT},
+                objective::AbstractVector{<:$scalarT},
+                sense::typeof($m))
 
-            return direct_call_solve_LP(
-                convert(pm_Matrix{pm_Rational}, inequalities),
-                convert(pm_Matrix{pm_Rational}, equalities),
-                convert(pm_Vector{pm_Rational}, objective),
-                $flag
-            )
-        end
-
-        function solve_LP(
-            inequalities::AbstractMatrix{<:AbstractFloat},
-            equalities::AbstractMatrix{<:AbstractFloat},
-            objective::AbstractVector{<:AbstractFloat}, ::typeof($m))
-
-            return direct_call_solve_LP_float(
-                convert(pm_Matrix{Float64}, inequalities),
-                convert(pm_Matrix{Float64}, equalities),
-                convert(pm_Vector{Float64}, objective),
-                $flag
-            )
+                return $pm_solve_LP(
+                    convert(pm_Matrix{$concreteT}, inequalities),
+                    convert(pm_Matrix{$concreteT}, equalities),
+                    convert(pm_Vector{$concreteT}, objective),
+                    $flag
+                )
+            end
         end
     end
 end


### PR DESCRIPTION
`solve_LP` in `polymake_direct_calls` is an example on how to call directly `libpolymake` functions;

in principle  generating such functions should be possible without (much) human intervention