### PR TITLE
V0.3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Polymake"
 uuid = "d720cf60-89b5-51f5-aff5-213f193123e7"
 repo = "https://github.com/oscar-system/Polymake.jl.git"
-version = "0.2.2"
+version = "0.3.0"
 
 [deps]
 BinaryProvider = "b99e7846-7c00-51b0-8f62-c81ae34c0232"

--- a/README.md
+++ b/README.md
@@ -78,11 +78,11 @@ Just remember that You need to `activate Polymake.jl` to use `Polymake`.
 
 In this section we just highlight various possible uses of `Polymake.jl`. Please refer to [Polymake syntax translation](#polymake-syntax-translation) for more thorough treatment.
 
-`polymake` big objects (like `Polytope`, `Cone`, etc) should be created with the help of `@pm` macro:
+`polymake` big objects (like `Polytope`, `Cone`, etc) constructors live within modules named after `polymake` applications, e.g.
 
 ```julia
 # Call the Polytope constructor
-julia> p = @pm Polytope.Polytope(POINTS=[1 -1 -1; 1 1 -1; 1 -1 1; 1 1 1; 1 0 0])
+julia> p = polytope.Polytope(POINTS=[1 -1 -1; 1 1 -1; 1 -1 1; 1 1 1; 1 0 0])
 type: Polytope<Rational>
 
 POINTS
@@ -95,10 +95,10 @@ POINTS
 ```
 Parameters could be passed as
 * keyword arguments (as above),
-* `Pair{Symbol, ...}`s e.g. `Polytope.Polytope(:POINTS=>[ ... ])`
-* dictionaries e.g. `Polytope.Polytope(Dict( "POINTS" => [ ... ] )`)
+* `Pair{Symbol, ...}`s e.g. `polytope.Polytope(:POINTS=>[ ... ])`
+* dictionaries e.g. `polytope.Polytope(Dict( "POINTS" => [ ... ] )`)
 
-The dictionary may hold many different attributes. All the names *must* be compatible with `polymake`.
+The dictionary may hold many different attributes. All the keys *must* be compatible with `polymake`.
 
 Properties of such objects can be accessed by the `.` syntax:
 ```
@@ -120,22 +120,22 @@ matrix_str = "["*replace(str, "/"=>"//")*"]"
 matrix = eval(Meta.parse(matrix_str))
 @show matrix
 
-p = @pm Polytope.Polytope(POINTS=matrix)
+p = polytope.Polytope(POINTS=matrix)
 
 @show p.FACETS # polymake matrix of polymake rationals
-@show Polytope.dim(p) # Julia Int64
+@show polytope.dim(p) # Julia Int64
 # note that even in Polymake property DIM is "fake" -- it's actually a function
 @show p.VERTEX_SIZES # polymake array of ints
 @show p.VERTICES
 
 for (i, vsize) in enumerate(p.VERTEX_SIZES)
-  if vsize == Polytope.dim(p)
+  if vsize == polytope.dim(p)
     println("$i : $(p.VERTICES[i,:])")
     # $i will be shifted by one from the polymake version
   end
 end
 
-simple_verts = [i for (i, vsize) in enumerate(p.VERTEX_SIZES) if vsize == Polytope.dim(p)] # Julia vector of Int64s
+simple_verts = [i for (i, vsize) in enumerate(p.VERTEX_SIZES) if vsize == polytope.dim(p)] # Julia vector of Int64s
 
 special_points = p.VERTICES[simple_verts, :] # polymake Matrix of rationals
 @show special_points;
@@ -189,15 +189,15 @@ special_points = pm::Matrix<pm::Rational>
 ```
 As can be seen we show consecutive steps of computations: the input `matrix`, `FACETS`, then we ask for `VERTEX_SIZES`, which triggers the convex hull computation. Then we show vertices and print those corresponding to simple vertices. Finally we collect them in `special_points`.
 
-Note that a `polymake` matrix tries to mimic the behaviour of Julia arrays: `p.VERTICES[2,:]` returns a `1`-dimensional slice (i.e. `pm_Vector`), while passing a set of indices (`p.VERTICES[special_points, :]`) returns a `2`-dimensional one.
+Observe that a `polymake` matrix (`pm_Matrix`) implements julia abstract array interface: `p.VERTICES[2,:]` returns a `1`-dimensional slice (i.e. `pm_Vector`), while passing a set of indices (`p.VERTICES[special_points, :]`) returns a `2`-dimensional one.
 
 #### Notes:
 
-The same minor (up to permutation of rows) could be obtained by using sets: either Julia or polymake sets. However since by default one can not index arrays with sets, we need to collect them first:
+The same minor (up to permutation of rows) could be obtained by using sets: either julia or polymake ones. However since by default one can not index arrays with sets, we need to collect them first:
 ```julia
-simple_verts = Set(i for (i, vsize) in enumerate(p.VERTEX_SIZES) if vsize == Polytope.dim(p)) # Julia set of Int64s
+simple_verts = Set(i for (i, vsize) in enumerate(p.VERTEX_SIZES) if vsize == polytope.dim(p)) # Julia set of Int64s
 
-simple_verts = pm_Set(i for (i, vsize) in enumerate(p.VERTEX_SIZES) if vsize == Polytope.dim(p)) # polymake set of longs
+simple_verts = pm_Set(i for (i, vsize) in enumerate(p.VERTEX_SIZES) if vsize == polytope.dim(p)) # polymake set of longs
 
 special_points = p.VERTICES[collect(simple_verts), :]
 ```
@@ -263,12 +263,12 @@ The following tables explain by example how to quickly translate `polymake` synt
 
 | Polymake                                                     | Julia                                                         |
 | ------------------------------------------------------------ | ------------------------------------------------------------- |
-| `$p=new Polytope<Rational>(POINTS=>cube(4)->VERTICES);`      | `p = @pm Polytope.Polytope(POINTS=Polytope.cube(4).VERTICES)` |
-| `$lp=new LinearProgram<Rational>(LINEAR_OBJECTIVE=>[0,1,1,1,1]);` | `lp = @pm Polytope.LinearProgram(LINEAR_OBJECTIVE=[0,1,1,1,1])` |
+| `$p=new Polytope<Rational>(POINTS=>cube(4)->VERTICES);`      | `p = polytope.Polytope(POINTS=polytope.cube(4).VERTICES)` |
+| `$lp=new LinearProgram<Rational>(LINEAR_OBJECTIVE=>[0,1,1,1,1]);` | `lp = polytope.LinearProgram(LINEAR_OBJECTIVE=[0,1,1,1,1])` |
 | `$p->LP=$lp;`<br>`$p->LP->MAXIMAL_VALUE;`                  | `p.LP = lp`<br>`p.LP.MAXIMAL_VALUE`                        |
 | `$i = ($p->N_FACETS * $p->N_FACETS) * 15;`                   | `i = (p.N_FACETS * p.N_FACETS) * 15`                         |
-| `$print p->DIM;`                                             | `Polytope.dim(p)`<br> `DIM` is actually a faux property, which hides a function beneath |
-| `application "topaz";`<br>`$p = new Polytope<Max, QuadraticExtension>(POINTS=>[[1,0,0], [1,1,0], [1,1,1]]);` | `p = @pm Tropical.Polytope{Max, QuadraticExtension}(POINTS=[1 0 0; 1 1 0; 1 1 1])` |
+| `$print p->DIM;`                                             | `polytope.dim(p)`<br> `DIM` is actually a faux property, which hides a function beneath |
+| `application "topaz";`<br>`$p = new Polytope<Max, QuadraticExtension>(POINTS=>[[1,0,0], [1,1,0], [1,1,1]]);` | `p = @pm tropical.Polytope{Max, QuadraticExtension}(POINTS=[1 0 0; 1 1 0; 1 1 1])`<br> more information on the @pm macro can be found below |
 
 ## Current state of the `polymake` wrapper
 
@@ -278,24 +278,69 @@ The following tables explain by example how to quickly translate `polymake` synt
 * Several small objects (data types) from `polymake` are available in `Polymake.jl`:
     * Integers (`pm_Integer <: Integer`)
     * Rationals (`pm_Rational <: Real`)
-    * Vectors (`pm_Vector <: AbstractVector`) of `pm_Integer`s and `pm_Rational`s
-    * Matrices (`pm_Matrix <: AbstractMatrix`) of `Float64`s, `pm_Integer`s and `pm_Rational`
+    * Vectors (`pm_Vector <: AbstractVector`) of of `Float64`s, `pm_Integer`s and `pm_Rational`s
+    * Matrices (`pm_Matrix <: AbstractMatrix`) of `Float64`s, `pm_Integer`s and `pm_Rational`s
     * Sets (`pm_Set <: AbstractSet`) of `Int32`s and `Int64`s
     * Arrays (`pm_Array <: AbstractVector`, as `pm_Arrays` are one-dimensional) of `Int32`s, `Int64`s and `pm_Integers`
     * some combinations thereof, e.g., `pm_Array`s of `pm_Sets` of `Int32`s.
 
 These data types can be converted to appropriate Julia types,
-but are also subtypes of the corresponding Julia abstract types (as indicated above), and so should be accepted by all methods that apply to the abstract types.
+but are also subtypes of the corresponding Julia abstract types (as indicated above),
+and so should be accepted by all methods that apply to the abstract types.
 
 **Note**: If the returned small object has not been wrapped in `Polymake.jl`
 yet, you will not be able to access its content or in general use it **from Julia**,
 however you can always pass it back as an argument to a `polymake` function.
-Moreover you may try to convert to Julia understandable type via
-`@pm Common.convert_to{wrapped{templated, type}}(obj)`.
-For example:
+Moreover you may try to convert to Julia understandable type via macro
+`@pm common.convert_to{C++{templated, type}}(obj)`.
 
+### Functions
+
+* All user functions from `polymake` are available in the appropriate modules, e.g. `homology` function from `topaz` can be called as `topaz.homology(...)` in julia. We pull the docstrings for functions from `polymake` as well, so `?topaz.homology` (in Julia's REPL) returns the `polymake` docstring. Note: the syntax presented in the docstring is a `polymake` syntax, not `Polymake.jl` one.
+* Most of the user functions from `polymake` are available as `appname.funcname(...)` in `Polymake.jl`.  Moreover, any function from `polymake` `C++` library can be called via macro call `@pm appname.funcname{C++{template, names}}(...)`.
+* All big objects of `polymake` can be constructed either via call to constructor, i.e.
 ```julia
-julia> c = Polytope.cube(3);
+obj = appname.BigObject(args)
+```
+One can specify some templates here as well: `polytope.Polytope{Float64}(...)` is a valid call, but the list of supported types is rather limited. Please consider filing a bug if a valid call results in `polymake` error.
+For more advanced use see section on `@pm` macro.
+* Properties of big objects are accessible by `bigobject.property` syntax (as opposed to `$bigobject->property` in `polymake`). If there is a missing property please check if it can be accessed by `appname.property(object)`. For example `polytope.Polytope` does not have `DIM` property in `Polymake.jl` sinc `DIM` is exposed as `polytope.dim(...)` function.
+* Methods are available as functions in the appropriate modules, with the first argument as the object, i.e. `$bigobj->methodname(...)` can be called via `appname.methodname(bigobj, ...)`
+* A function in `Polymake.jl` calling `polymake` may return a big or small object, and the generic return (`PropertyValue`) is transparently converted to one of the known data types. This conversion can be deactivated by adding `keep_PropertyValue=true` keyword argument to function/method call.
+
+### `@pm` macro
+
+The `@pm` macro can be used to issue more complicated calls to polymake from julia.
+If You need to pass templates to `BigObject`s, some limited support is provided in costructors.
+For example one can construct `polytope.Polytope{Float64}(...)`.
+However for this to work templates need to be valid julia types/object, hence
+it is not possible to construct a `Polytope<QuadraticExtension>` through such call.
+For this (and in general: for passing more complicated templates) one needs the
+`@pm` macro:
+```perl
+$obj = new BigObject<Template,Parameters>(args)
+```
+becomes
+```julia
+obj = @pm Appname.BigObject{Template, Parameters}(args)
+```
+
+Examples:
+```julia
+tropical.Polytope{max, pm_Rational}(POINTS=[1 0 0; 1 1 0; 1 1 1])
+# call to constructor, note that max is a julia function, hence a valid object
+@pm tropical.Polytope{Max, QuadraticExtension}(POINTS=[1 0 0; 1 1 0; 1 1 1])
+# macro call: none of the types in templates need to exist in julia
+```
+
+As a rule of thumb any template passed to `@pm` macro needs to be translatable
+on syntax level to a `C++` one. E.g. `Matrix{Integer}` works, as it translates to
+`pm::Matrix<pm::Integer>`.
+
+Such templates can be passed to functions as well. A very useful example is the
+`common.convert_to`:
+```julia
+julia> c = polytope.cube(3);
 
 julia> f = c.FACETS;
 
@@ -304,7 +349,7 @@ ERROR: MethodError: no method matching getindex(::Polymake.pm_perl_PropertyValue
 Stacktrace:
   [...]
 
-julia> m = @pm Common.convert_to{Matrix{Integer}}(f)
+julia> m = @pm common.convert_to{Matrix{Integer}}(f) # the template must consist of C++ names
 pm::Matrix<pm::Integer>
 1 1 0 0
 1 -1 0 0
@@ -318,22 +363,6 @@ julia> m[1,1]
 
 ```
 
-### Functions
-
-* All user functions from `polymake` are available in the appropriate modules, e.g. `homology` function from `topaz` can be called as `Topaz.homology(...)` in Julia. We pull the docstrings for functions from `polymake` as well, so `?Topaz.homology` (in Julia's REPL) returns a `polymake` docstring. Note: the syntax presented in the docstring is a `polymake` syntax, not `Polymake.jl` one.
-* Most of the user functions from `polymake` are available as `Appname.funcname(...)` in `Polymake.jl`.  Moreover, any function from `polymake` `C++` library can be called via `@pm Appname.funcname(...)` macro. If you happen to use a non-user `polymake` function in REPL quite often you might `Polymake.@register Appname.funcname` so that it becomes available for completion. This is a purely convenience macro, as the effects of `@register` will be lost when Julia kernel restarts.
-* All big objects of `polymake` can be constructed via `@pm` macro. For example
-```perl
-$obj = new BigObject<Template,Parameters>(args)
-```
-becomes
-```julia
-obj = @pm Appname.BigObject{Templete,Parameters}(args)
-```
-See Section Polymake syntax translation for concrete examples.
-* Properties of big objects are accessible by `bigobject.property` syntax (as opposed to `$bigobject->property` in `polymake`). If there is a missing property (e.g. `Polytope.Polytope` does not have `DIM` property in `Polymake.jl`), please check if it can be accessed by `Appname.property(object)`. For example property `DIM` is exposed as `Polytope.dim(...)` function.
-* Methods are available as functions in the appropriate modules, with the first argument as the object, i.e. `$bigobj->methodname(...)` can be called via `Appname.methodname(bigobj, ...)`
-* A function in `Polymake.jl` calling `polymake` may return a big or small object, and the generic return (`PropertyValue`) is transparently converted to one of the data types above. If you really care about performance, this conversion can be deactivated by adding `keep_PropertyValue=true` keyword argument to function/method call.
 
 ### Function Arguments
 
@@ -345,7 +374,7 @@ Functions in `Polymake.jl` accept the following types for their arguments:
   *  `pm_perl_PropertyValue` (containers opaque to Julia)
 <!-- *  `pm_perl_OptionSet` -->
 
-If an object passed to `Polymake.jl` function is of a different type the software will try its best to convert it to such. However, if the conversion doesn't work the `ArgumentError` will be thrown:
+If an object passed to `Polymake.jl` function is of a different type the software will try its best to convert it to a known one. However, if the conversion doesn't work an `ArgumentError` will be thrown:
 ```julia
 ERROR: ArgumentError: Unrecognized argument type: SomeType.
 You need to convert to polymake compatible type first.
@@ -353,9 +382,9 @@ You need to convert to polymake compatible type first.
 
 You can tell `Polymake.jl` how to convert it by definig
 ```julia
-Base.convert(::Type{Polymake.PolymakeType}, ma::SomeType)
+Base.convert(::Type{Polymake.PolymakeType}, x::SomeType)
 ```
-The returned value must be of one of the types as above. For example to use `AbstractAlgebra` matrices as input to `Polymake.jl` one may define
+The returned value must be of one of the types as above. For example to use `AbstractAlgebra.jl` matrices as input to `Polymake.jl` one may define
 ```julia
 Base.convert(::Type{Polymake.PolymakeType}, M::Generic.MatSpaceElem) = pm_Matrix(M.entries)
 ```
@@ -375,14 +404,14 @@ julia> mm = AbstractAlgebra.matrix(ZZ, [1 2 3; 4 5 6])
 [1 2 3]
 [4 5 6]
 
-julia> @pm Polytope.Polytope(POINTS=mm)
+julia> polytope.Polytope(POINTS=mm)
 ERROR: ArgumentError: Unrecognized argument type: AbstractAlgebra.Generic.MatSpaceElem{Int64}.
 You need to convert to polymake compatible type first.
   [...]
 
 julia> Base.convert(::Type{Polymake.PolymakeType}, M::Generic.MatSpaceElem) = pm_Matrix(M.entries)
 
-julia> @pm Polytope.Polytope(POINTS=mm)
+julia> polytope.Polytope(POINTS=mm)
 type: Polytope<Rational>
 
 POINTS

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ special_points = pm::Matrix<pm::Rational>
 ```
 As can be seen we show consecutive steps of computations: the input `matrix`, `FACETS`, then we ask for `VERTEX_SIZES`, which triggers the convex hull computation. Then we show vertices and print those corresponding to simple vertices. Finally we collect them in `special_points`.
 
-Observe that a `polymake` matrix (`pm_Matrix`) implements julia abstract array interface: `p.VERTICES[2,:]` returns a `1`-dimensional slice (i.e. `pm_Vector`), while passing a set of indices (`p.VERTICES[special_points, :]`) returns a `2`-dimensional one.
+Observe that a `polymake` matrix (`Polymake.Matrix`) implements julia abstract array interface: `p.VERTICES[2,:]` returns a `1`-dimensional slice (i.e. `Polymake.Vector`), while passing a set of indices (`p.VERTICES[special_points, :]`) returns a `2`-dimensional one.
 
 #### Notes:
 
@@ -197,7 +197,7 @@ The same minor (up to permutation of rows) could be obtained by using sets: eith
 ```julia
 simple_verts = Set(i for (i, vsize) in enumerate(p.VERTEX_SIZES) if vsize == polytope.dim(p)) # Julia set of Int64s
 
-simple_verts = pm_Set(i for (i, vsize) in enumerate(p.VERTEX_SIZES) if vsize == polytope.dim(p)) # polymake set of longs
+simple_verts = Polymake.Set(i for (i, vsize) in enumerate(p.VERTEX_SIZES) if vsize == polytope.dim(p)) # polymake set of longs
 
 special_points = p.VERTICES[collect(simple_verts), :]
 ```
@@ -276,13 +276,13 @@ The following tables explain by example how to quickly translate `polymake` synt
 
 * Big objects, e.g., Polytopes, can be handled in Julia.
 * Several small objects (data types) from `polymake` are available in `Polymake.jl`:
-    * Integers (`pm_Integer <: Integer`)
-    * Rationals (`pm_Rational <: Real`)
-    * Vectors (`pm_Vector <: AbstractVector`) of of `Float64`s, `pm_Integer`s and `pm_Rational`s
-    * Matrices (`pm_Matrix <: AbstractMatrix`) of `Float64`s, `pm_Integer`s and `pm_Rational`s
-    * Sets (`pm_Set <: AbstractSet`) of `Int32`s and `Int64`s
-    * Arrays (`pm_Array <: AbstractVector`, as `pm_Arrays` are one-dimensional) of `Int32`s, `Int64`s and `pm_Integers`
-    * some combinations thereof, e.g., `pm_Array`s of `pm_Sets` of `Int32`s.
+    * Integers (`Polymake.Integer <: Integer`)
+    * Rationals (`Polymake.Rational <: Real`)
+    * Vectors (`Polymake.Vector <: AbstractVector`) of `Int64`s, `Float64`s, `Polymake.Integer`s and `Polymake.Rational`s
+    * Matrices (`Polymake.Matrix <: AbstractMatrix`) of `Int64`s, `Float64`s, `Polymake.Integer`s and `Polymake.Rational`s
+    * Sets (`Polymake.Set <: AbstractSet`) of `Int64`s
+    * Arrays (`Polymake.Array <: AbstractVector`, as `Polymake.Arrays` are one-dimensional) of `Int64`s and `Polymake.Integers`
+    * some combinations thereof, e.g., `Polymake.Array`s of `Polymake.Sets` of `Int32`s.
 
 These data types can be converted to appropriate Julia types,
 but are also subtypes of the corresponding Julia abstract types (as indicated above),
@@ -322,12 +322,12 @@ $obj = new BigObject<Template,Parameters>(args)
 ```
 becomes
 ```julia
-obj = @pm Appname.BigObject{Template, Parameters}(args)
+obj = @pm appname.BigObject{Template, Parameters}(args)
 ```
 
 Examples:
 ```julia
-tropical.Polytope{max, pm_Rational}(POINTS=[1 0 0; 1 1 0; 1 1 1])
+tropical.Polytope{max, Polymake.Rational}(POINTS=[1 0 0; 1 1 0; 1 1 1])
 # call to constructor, note that max is a julia function, hence a valid object
 @pm tropical.Polytope{Max, QuadraticExtension}(POINTS=[1 0 0; 1 1 0; 1 1 1])
 # macro call: none of the types in templates need to exist in julia
@@ -345,7 +345,7 @@ julia> c = polytope.cube(3);
 julia> f = c.FACETS;
 
 julia> f[1,1] # f is an opaque pm::perl::PropertyValue to julia
-ERROR: MethodError: no method matching getindex(::Polymake.pm_perl_PropertyValueAllocated, ::Int64, ::Int64)
+ERROR: MethodError: no method matching getindex(::Polymake.PropertyValueAllocated, ::Int64, ::Int64)
 Stacktrace:
   [...]
 
@@ -368,11 +368,10 @@ julia> m[1,1]
 
 Functions in `Polymake.jl` accept the following types for their arguments:
 * simple data types (bools, machine integers, floats)
-* wrapped native types (`pm_Integer`, `pm_Rational`, `pm_Vector`, `pm_Matrix`, `pm_Set` etc.)
+* wrapped native types (`Polymake.Integer`, `Polymake.Rational`, `Polymake.Vector`, `Polymake.Matrix`, `Polymake.Set` etc.)
 * other objects returned by polymake:
-  *  `pm_perl_Object` (essentially Big Objects),
-  *  `pm_perl_PropertyValue` (containers opaque to Julia)
-<!-- *  `pm_perl_OptionSet` -->
+  *  `Polymake.BigObject`,
+  *  `Polymake.PropertyValue` (containers opaque to Julia)
 
 If an object passed to `Polymake.jl` function is of a different type the software will try its best to convert it to a known one. However, if the conversion doesn't work an `ArgumentError` will be thrown:
 ```julia
@@ -386,13 +385,13 @@ Base.convert(::Type{Polymake.PolymakeType}, x::SomeType)
 ```
 The returned value must be of one of the types as above. For example to use `AbstractAlgebra.jl` matrices as input to `Polymake.jl` one may define
 ```julia
-Base.convert(::Type{Polymake.PolymakeType}, M::Generic.MatSpaceElem) = pm_Matrix(M.entries)
+Base.convert(::Type{Polymake.PolymakeType}, M::Generic.MatSpaceElem) = Polymake.Matrix(M.entries)
 ```
 and the following should run smoothly.
 ```julia
 julia> using AbstractAlgebra, Polymake
-polymake version 3.4
-Copyright (c) 1997-2019
+polymake version 4.0
+Copyright (c) 1997-2020
 Ewgenij Gawrilow, Michael Joswig (TU Berlin)
 https://polymake.org
 
@@ -409,7 +408,7 @@ ERROR: ArgumentError: Unrecognized argument type: AbstractAlgebra.Generic.MatSpa
 You need to convert to polymake compatible type first.
   [...]
 
-julia> Base.convert(::Type{Polymake.PolymakeType}, M::Generic.MatSpaceElem) = pm_Matrix(M.entries)
+julia> Base.convert(::Type{Polymake.PolymakeType}, M::Generic.MatSpaceElem) = Polymake.Matrix(M.entries)
 
 julia> polytope.Polytope(POINTS=mm)
 type: Polytope<Rational>

--- a/README.md
+++ b/README.md
@@ -23,16 +23,13 @@ This will fetch a pre-built binary of `polymake`. You are ready to start `using 
 
 Note: Pre-built binaries are available for the `Linux` and `macOS` platform, but the `macOS` binaries are considered experimental. Windows users are encouraged to try running Julia inside Window Subsystem for Linux and reporting back ;)
 
-To skip the test for `polymake-config` in the `PATH` and directly use the pre-built binaries you need to set `POLYMAKE_CONFIG=no` in your environment.
-
 Note: Pre-built polymake will use a separate `.polymake` config directory (usually `joinpath(homedir(), ".julia", "polymake_user")`).
 
 ### Your own installation of `polymake`
 
-If you already have a recent enough version of `polymake` (i.e. `>=3.3`) on your system,
-you either need to make `polymake-config` available in your `PATH` or
-the environment variable `POLYMAKE_CONFIG` needs to point to the correct
-`polymake-config` file.
+If you already have a recent enough version of `polymake` (i.e. `>=4.0`) on your system and you want to use this version of `polymake`, you either need to
+ * set the environment variable `POLYMAKE_CONFIG=yes` and make `polymake-config` available in your `PATH` or
+ * set the environment variable `POLYMAKE_CONFIG` to the full path of the `polymake-config` executable.
 
 After this just `add` the package as above (or `build` if the package has been already added), the build script will use your `polymake` installation.
 
@@ -59,14 +56,14 @@ After this start Julia and follow the instructions above.
 Note: Self-built polymake will use the standard `.polymake` config directory (usually `$HOME/.polymake`).
 
 ### `Polymake.jl` in a separate environment:
-First clone `Polymake.jl`:
 ```
-git clone https://github.com/oscar-system/Polymake.jl.git
+mkdir my_new_env
+cd my_new_env
 ```
-In the same directory start Julia and press `]` for `pkg` mode. Then run
+Then start Julia in the directory and press `]` for `pkg` mode.
 ```julia
-(v1.0) pkg> activate Polymake.jl
-(Polymake) pkg> instantiate
+(v1.3) pkg> activate .
+(Polymake) pkg> dev --local Polymake
 (Polymake) pkg> build Polymake # fetches the prebuild polymake binaries
 (Polymake) pkg> test Polymake # and You are good to go!
 ```

--- a/README.md
+++ b/README.md
@@ -90,12 +90,8 @@ POINTS
 1 0 0
 
 ```
-Parameters could be passed as
-* keyword arguments (as above),
-* `Pair{Symbol, ...}`s e.g. `polytope.Polytope(:POINTS=>[ ... ])`
-* dictionaries e.g. `polytope.Polytope(Dict( "POINTS" => [ ... ] )`)
-
-The dictionary may hold many different attributes. All the keys *must* be compatible with `polymake`.
+Parameters to constructors can be passed as keyword arguments only.
+All the keys *must* be compatible with `polymake` input attribute names.
 
 Properties of such objects can be accessed by the `.` syntax:
 ```

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -32,18 +32,22 @@ perl = joinpath(@__DIR__,"usr","bin","perl")
 use_binary = true
 depsjl = ""
 
-if !( haskey(ENV, "POLYMAKE_CONFIG") && ENV["POLYMAKE_CONFIG"] == "no" )
+if haskey(ENV, "POLYMAKE_CONFIG") && ENV["POLYMAKE_CONFIG"] != "no"
     try
-        # test whether polymake config is available in path
-        global pm_config = chomp(read(`command -v polymake-config`, String))
+        if ENV["POLYMAKE_CONFIG"] == "yes"
+            # test whether polymake config is available in path
+            global pm_config = chomp(read(`command -v polymake-config`, String))
+        else
+            global pm_config = ENV["POLYMAKE_CONFIG"]
+        end
+        @assert ispath(pm_config)
         global perl ="perl"
         global use_binary = false
-    catch
-        if haskey(ENV, "POLYMAKE_CONFIG")
-            global pm_config = ENV["POLYMAKE_CONFIG"]
-            global perl ="perl"
-            global use_binary = false
+    catch err
+        if err isa AssertionError
+            @error("Environment variable POLYMAKE_CONFIG does not point to a valid `polymake-config` executable.")
         end
+        rethrow(err)
     end
 end
 

--- a/deps/src/polymake_bigobjects.cpp
+++ b/deps/src/polymake_bigobjects.cpp
@@ -60,6 +60,9 @@ void polymake_module_add_bigobject(jlcxx::Module& polymake)
     });
     polymake.method("to_bigobject", &to_bigobject);
 
+    polymake.method("setname!", [](pm::perl::BigObject p, const std::string& s){
+        p.set_name(s);
+    });
     polymake.method("take", [](pm::perl::BigObject p, const std::string& s,
                                const std::string& t) { p.take(s) << t; });
     polymake.method("take",

--- a/src/Polymake.jl
+++ b/src/Polymake.jl
@@ -1,9 +1,6 @@
 module Polymake
 
-export BigObject, PropertyValue,
-       PolymakeError, application, dual_zero, orientation,
-       prefer
-
+export @pm, visual
 
 # We need to import all functions which will be extended on the Cxx side
 import Base: ==, <, <=, *, -, +, //, div, rem, one, zero,

--- a/src/call_function.jl
+++ b/src/call_function.jl
@@ -1,5 +1,3 @@
-export @pm
-
 function CxxWrap.StdVector{CxxWrap.StdString}(vec::AbstractVector{<:AbstractString})
     return CxxWrap.StdVector(convert.(CxxWrap.StdString, vec))
 end
@@ -115,7 +113,7 @@ macro pm(expr)
         polymake_func_name =
             Meta.pm_name_qualified(polymake_app, polymake_func, templates)
         return :(
-            bigobj($polymake_func_name, $(esc.(args)...), $(esc.(kwargs)...))
+            bigobject($polymake_func_name, $(esc.(args)...); $(esc.(kwargs)...))
             )
     else # we presume it's a function
         app = "$polymake_app"

--- a/src/meta.jl
+++ b/src/meta.jl
@@ -301,8 +301,8 @@ function jl_constructor(jl_name::Symbol, pm_name::String, app_name::String)
     return quote
         function $(jl_name)(args...; kwargs...)
             # name created at compile-time
-            return bigobj($(pm_name_qualified(app_name, pm_name)),
-                args..., kwargs...)
+            return bigobject($(pm_name_qualified(app_name, pm_name)),
+                args...; kwargs...)
         end
     end
 end
@@ -313,7 +313,7 @@ function jl_constructor(jl_name::Symbol, pm_name::String, app_name::String, temp
             Ts = translate_type_to_pm_string.([$(templates...)])
             # name created at run-time
             pm_full_name = pm_name_qualified($(app_name), $(pm_name), Ts)
-            return bigobj(pm_full_name, args..., kwargs...)
+            return bigobject(pm_full_name, args...; kwargs...)
         end
     end
 end
@@ -364,7 +364,7 @@ end
 Base.show(io::IO, doc::PolymakeDocstring) = print(io, doc.s)
 
 module_imports() = quote
-    import Polymake: call_function, call_method, bigobj,
+    import Polymake: call_function, call_method, bigobject,
         BigObject, OptionSet, PropertyValue
     import Polymake.CxxWrap
     import Polymake.Meta: PolymakeDocstring, pm_name_qualified,

--- a/src/perlobj.jl
+++ b/src/perlobj.jl
@@ -1,25 +1,23 @@
-function bigobj(name::String, input_data::Dict{<:Union{String, Symbol},T}) where T
-    perl_obj = BigObject(name)
-    for value in input_data
-        key = string(value[1])
-        val = convert(PolymakeType, value[2])
-        take(perl_obj,key,val)
-    end
-    return perl_obj
+function bigobject(fname::String; kwargsdata...)
+    obj = BigObject(fname)
+    setproperties!(obj; kwargsdata...)
+    return obj
 end
 
-function bigobj(name::String, input_data::Pair{<:Union{Symbol,String}}...; kwargsdata...)
-    obj = BigObject(name)
-    for (key, val) in input_data
-        setproperty!(obj, string(key), val)
-    end
+function bigobject(fname::String, name::String; kwargsdata...)
+    obj = bigobject(fname; kwargsdata...)
+    setname!(obj, name)
+    return obj
+end
+
+function setproperties!(obj::BigObject; kwargsdata...)
     for (key, val) in kwargsdata
         setproperty!(obj, string(key), val)
     end
     return obj
 end
 
-Base.propertynames(p::Polymake.BigObject) = Symbol.(complete_property(p, ""))
+Base.propertynames(p::BigObject) = Symbol.(Polymake.complete_property(p, ""))
 
 function Base.setproperty!(obj::BigObject, prop::Symbol, val)
     @assert prop != :cpp_object
@@ -33,11 +31,12 @@ end
 
 Base.setproperty!(obj::BigObject, prop::String, val) = setproperty!(obj, Symbol(prop), val)
 
-function give(obj::Polymake.BigObject, prop::String)
+function give(obj::BigObject, prop::String)
     return_obj = try
         internal_give(obj, prop)
     catch ex
-        throw(PolymakeError(ex.msg))
+        ex isa ErrorException && throw(PolymakeError(ex.msg))
+        rethrow(ex)
     end
     return convert_from_property_value(return_obj)
 end
@@ -54,8 +53,8 @@ function complete_property(obj::BigObject, prefix::String)
    call_function(:common, :complete_property, obj, prefix)
 end
 
-function convert_from_property_value(obj::Polymake.PropertyValue)
-    type_name = Polymake.typeinfo_string(obj,true)
+function convert_from_property_value(obj::PropertyValue)
+    type_name = typeinfo_string(obj,true)
     T = Symbol(replace(type_name," "=>""))
     if haskey(TypeConversionFunctions, T)
         f = TypeConversionFunctions[T]

--- a/src/visual.jl
+++ b/src/visual.jl
@@ -106,6 +106,9 @@ function Base.show(io::IO,::MIME"image/svg+xml",v::Visual)
     print(io,_get_visual_string_svg(v))
 end
 
+display_svg(obj::BigObject) = display_svg(visual(obj))
+display_svg(v::Visual) = display(MIME"image/svg+xml"(), v)
+
 """
     visual(obj::BigObject; options...)
 

--- a/src/visual.jl
+++ b/src/visual.jl
@@ -1,24 +1,60 @@
 export visual
 
-Base.show(io::IO,::MIME"text/plain", obj::BigObject) = print(io, properties(obj))
+function Base.show(io::IO,::MIME"text/plain", obj::BigObject)
+    strs = strip.(split(String(properties(obj)), "\n\n"))
+    summary = strs[1]
+    props = filter!(!isempty, strs[2:end])
+    println(io, summary)
 
-function Base.show(io::IO,::MIME"text/html",obj::BigObject)
-    return_string = properties(obj)
-    summary, description = split(return_string,"\n";limit=2)
-    if startswith(summary, "type: ")
-        summary = summary[7:end]
+    upperbound = 10
+    for p in props
+        if occursin('\n', p)
+            (key, val) = split(p, '\n'; limit=2)
+        else
+            key, val = p, ""
+        end
+
+        if key in ("POINTS", "INEQUALITIES", "FACETS", "VERTICES")
+            println(io, '\n', key)
+            try
+                Base.print_matrix(io, getproperty(obj, Symbol(key)), "  ")
+                println(io, "")
+            catch
+                println(io, "\t", val)
+            end
+        else
+            if count(r"\n", val) > upperbound
+                val = join(
+                        split(val, "\n"; limit=upperbound+1)[1:upperbound],
+                    "\n") * "\n…"
+            end
+            println(io, '\n', key)
+            println(io, "\t", replace(val, "\n"=>"\n\t"))
+        end
     end
-    if startswith(description, "description: ")
-        description = description[14:end]
+end
+
+function Base.show(io::IO, ::MIME"text/html", obj::BigObject)
+
+    strs = strip.(split(String(properties(obj)), "\n\n"))
+    summary = split(strs[1], "\n")
+    attributes = filter!(!isempty, strs[2:end])
+
+    props = Base.Vector{String}(undef, length(attributes))
+
+    for (i, a) in enumerate(attributes)
+        if occursin('\n', a)
+            (key, val) = split(a, '\n'; limit=2)
+        else
+            key, val = a, ""
+        end
+
+        props[i] = "<details><summary>$key</summary><pre>$val</pre></details>"
     end
-    print(io,"""
-<details>
-<summary>$summary</summary>
-    <pre>
-$description
-    </pre>
-</details>
-""")
+
+    preamble = ("<dt>$t</dt><dd>$d</dd>" for (t,d) in split.(summary, ":"; limit=2))
+
+    print(io, "<dl> $(join(preamble, "\n")) </dl>", join(props, "\n"))
 end
 
 function Base.show(io::IO, ::MIME"text/plain", obj::SmallObject)

--- a/test/interface_functions.jl
+++ b/test/interface_functions.jl
@@ -5,18 +5,18 @@
         @test polytope.pseudopower(args...) == val
     end
 
-    @test Polymake.call_function(:polytope, :cube, 2) isa BigObject
-    @test polytope.cube( 2 ) isa BigObject
-    @test (@pm polytope.cube{Rational}( 3 )) isa BigObject
+    @test Polymake.call_function(:polytope, :cube, 2) isa Polymake.BigObject
+    @test polytope.cube( 2 ) isa Polymake.BigObject
+    @test (@pm polytope.cube{Rational}( 3 )) isa Polymake.BigObject
     c = @pm polytope.cube{Rational}( 3 )
     cc = polytope.cube( 3 )
     @test Polymake.call_function(:polytope, :equal_polyhedra,c,cc)
     @test @pm polytope.equal_polyhedra(c, cc)
     @test polytope.equal_polyhedra(c, cc)
 
-    @test tropical.cyclic(3,5,template_parameters=["Max"]) isa BigObject
+    @test tropical.cyclic(3,5,template_parameters=["Max"]) isa Polymake.BigObject
 
-    @test (@pm tropical.cyclic{Max}(3,5)) isa BigObject
+    @test (@pm tropical.cyclic{Max}(3,5)) isa Polymake.BigObject
 
     @test Base.Docs.getdoc(polytope.Polytope) isa Polymake.Meta.PolymakeDocstring
     a = Base.Docs.getdoc(polytope.Polytope)

--- a/test/perlobj.jl
+++ b/test/perlobj.jl
@@ -78,7 +78,7 @@
     @testset "PolymakeException" begin
         test_polytope = @pm polytope.Polytope(POINTS=points_int)
         @test !(:STH in Base.propertynames(test_polytope))
-        @test_throws PolymakeError test_polytope.STH
+        @test_throws Polymake.PolymakeError test_polytope.STH
     end
 
     @testset "properties" begin

--- a/test/perlobj.jl
+++ b/test/perlobj.jl
@@ -1,29 +1,29 @@
-@testset "bigobj" begin
-    input_dict_int = Dict( "POINTS" => [ 1 0 0 ; 1 3 0 ; 1 0 3 ; 1 3 3 ] )
-    input_dict_rat = Dict( "POINTS" => Base.Array{Base.Rational{Int64},2}([ 1 0 0 ; 1 3 0 ; 1 0 3 ; 1 3 3 ]) )
-    input_dict_unbounded = Dict("POINTS" => [1 0 0; 0 1 1])
+@testset "bigobject" begin
+    points_int = [ 1 0 0 ; 1 3 0 ; 1 0 3 ; 1 3 3 ]
+    points_rat = [ 1 0 0 ; 1 3 0 ; 1 0 3 ; 1 3 3 ]
+    points_unbounded = [1 0 0; 0 1 1]
 
     @testset "constructors" begin
-        @test Polymake.bigobj("polytope::Polytope", input_dict_int ) isa BigObject
-        @test Polymake.bigobj("polytope::Polytope", input_dict_rat ) isa BigObject
+        # @test Polymake.bigobject("polytope::Polytope", POINTS=points_int ) isa bigobjectect
+        # @test Polymake.bigobject("polytope::Polytope", POINTS=points_rat ) isa bigobjectect
         A = [ 1 0 0 ; 1 3 0 ; 1 0 3 ; 1 3 3 ]
-        @test Polymake.bigobj("polytope::Polytope", POINTS=A) isa BigObject
-        @test Polymake.bigobj("polytope::Polytope", :POINTS => A) isa BigObject
+        @test Polymake.bigobject("polytope::Polytope", POINTS=A) isa Polymake.BigObject
+        # @test Polymake.bigobject("polytope::Polytope", :POINTS => A) isa bigobjectect
         # macro literals
-        @test (@pm polytope.Polytope(POINTS=[ 1 0 0 ; 1 3 0 ; 1 0 3 ; 1 3 3 ])) isa BigObject
-        @test (@pm polytope.Polytope(:POINTS=>[ 1 0 0 ; 1 3 0 ; 1 0 3 ; 1 3 3 ])) isa BigObject
-        @test (@pm polytope.Polytope("POINTS"=>[ 1 0 0 ; 1 3 0 ; 1 0 3 ; 1 3 3 ])) isa BigObject
+        @test (@pm polytope.Polytope(POINTS=[ 1 0 0 ; 1 3 0 ; 1 0 3 ; 1 3 3 ])) isa Polymake.BigObject
+        # @test (@pm polytope.Polytope(:POINTS=>[ 1 0 0 ; 1 3 0 ; 1 0 3 ; 1 3 3 ])) isa Polymake.BigObject
+        # @test (@pm polytope.Polytope("POINTS"=>[ 1 0 0 ; 1 3 0 ; 1 0 3 ; 1 3 3 ])) isa Polymake.BigObject
 
         # Make sure that we can also handle different matrix types, e.g. adjoint
-        @test (@pm polytope.Polytope(POINTS=A')) isa BigObject
+        @test (@pm polytope.Polytope(POINTS=A')) isa Polymake.BigObject
 
         pm1 = Polymake.Integer(1)
         pm2 = Polymake.Integer(2)
-        @test (@pm polytope.Polytope(POINTS=[pm1 pm2])) isa BigObject
-        @test (@pm polytope.Polytope(POINTS=[pm1//pm2 pm2//pm2])) isa BigObject
-        @test (@pm polytope.Polytope(POINTS=[1//2 1//2])) isa BigObject
+        @test (@pm polytope.Polytope(POINTS=[pm1 pm2])) isa Polymake.BigObject
+        @test (@pm polytope.Polytope(POINTS=[pm1//pm2 pm2//pm2])) isa Polymake.BigObject
+        @test (@pm polytope.Polytope(POINTS=[1//2 1//2])) isa Polymake.BigObject
 
-        @test polytope.cube(3, 1//4, -1//4) isa BigObject
+        @test polytope.cube(3, 1//4, -1//4) isa Polymake.BigObject
 
         function test_pm_macro()
             P = @pm polytope.cube(3)
@@ -36,26 +36,33 @@
 
         @test polytope.cube(Polymake.PropertyValue, 3) isa Polymake.PropertyValue
         c = polytope.cube(Polymake.PropertyValue, 3);
-        @test polytope.spherize(c) isa BigObject
+        @test polytope.spherize(c) isa Polymake.BigObject
+
+        @testset "giving polytope a name" begin
+            p = polytope.rand_sphere(3,20);
+            @test polytope.Polytope("my cuttie", INEQUALITIES=p.POINTS) isa Polymake.BigObject
+            P = polytope.Polytope("my cuttie", INEQUALITIES=p.POINTS)
+            @test occursin("my cuttie", Polymake.properties(P))
+        end
     end
 
     @testset "template parameters" begin
-        @test (@pm polytope.Polytope(input_dict_int)) isa BigObject
-        @test (@pm polytope.Polytope{Rational}(input_dict_int)) isa BigObject
-        @test (@pm polytope.Polytope{QuadraticExtension}(input_dict_int)) isa BigObject
-        @test (@pm polytope.Polytope{QuadraticExtension{Rational}}(input_dict_int)) isa BigObject
+        @test (@pm polytope.Polytope(POINTS=points_int)) isa Polymake.BigObject
+        @test (@pm polytope.Polytope{Rational}(POINTS=points_int)) isa Polymake.BigObject
+        @test (@pm polytope.Polytope{QuadraticExtension}(POINTS=points_int)) isa Polymake.BigObject
+        @test (@pm polytope.Polytope{QuadraticExtension{Rational}}(POINTS=points_int)) isa Polymake.BigObject
 
-        @test (@pm polytope.Polytope(input_dict_rat)) isa BigObject
+        @test (@pm polytope.Polytope(POINTS=points_rat)) isa Polymake.BigObject
 
-        @test (@pm tropical.Polytope{Max}(input_dict_int)) isa BigObject
+        @test (@pm tropical.Polytope{Max}(POINTS=points_int)) isa Polymake.BigObject
 
-        @test (@pm tropical.Polytope{Max}(input_dict_int)) isa BigObject
-        @test (@pm tropical.Polytope{Max, Rational}(input_dict_int)) isa BigObject
-        @test (@pm tropical.Polytope{Max, QuadraticExtension}(input_dict_int)) isa BigObject
+        @test (@pm tropical.Polytope{Max}(POINTS=points_int)) isa Polymake.BigObject
+        @test (@pm tropical.Polytope{Max, Rational}(POINTS=points_int)) isa Polymake.BigObject
+        @test (@pm tropical.Polytope{Max, QuadraticExtension}(POINTS=points_int)) isa Polymake.BigObject
 
         @test (@pm tropical.Hypersurface{Min}(
             MONOMIALS=[1 0 0; 0 1 0; 0 0 1],
-            COEFFICIENTS=[0, 0, 0])) isa BigObject
+            COEFFICIENTS=[0, 0, 0])) isa Polymake.BigObject
         # note: You need to input COEFFICIENTS as Polymake.Vector, otherwise it will be converted to Polymake.Matrix which polymake doesn't like.
 
         P = @pm polytope.Polytope{Float}(POINTS=[1 1//2 0; 1 0 1])
@@ -69,24 +76,24 @@
     end
 
     @testset "PolymakeException" begin
-        test_polytope = @pm polytope.Polytope(input_dict_int)
+        test_polytope = @pm polytope.Polytope(POINTS=points_int)
         @test !(:STH in Base.propertynames(test_polytope))
         @test_throws PolymakeError test_polytope.STH
     end
 
     @testset "properties" begin
-        test_polytope = @pm polytope.Polytope(input_dict_int)
+        test_polytope = @pm polytope.Polytope(POINTS=points_int)
         @test test_polytope.F_VECTOR == [ 4, 4 ]
         @test test_polytope.INTERIOR_LATTICE_POINTS ==
             [ 1 1 1 ; 1 1 2 ; 1 2 1 ; 1 2 2 ]
 
-        @test test_polytope.GRAPH isa BigObject
+        @test test_polytope.GRAPH isa Polymake.BigObject
         test_graph = test_polytope.GRAPH
         @test :ADJACENCY in Base.propertynames(test_graph)
 
         @test test_polytope.LATTICE_POINTS_GENERATORS isa Polymake.Array
 
-        test_polytope = @pm polytope.Polytope(input_dict_unbounded)
+        test_polytope = @pm polytope.Polytope(POINTS=points_unbounded)
         @test test_polytope.FAR_FACE == Polymake.Set([1])
 
         c = polytope.cube(3, 1//4, -1//4)
@@ -94,7 +101,7 @@
     end
 
     @testset "tab-completion" begin
-        test_polytope = @pm polytope.Polytope(input_dict_int)
+        test_polytope = @pm polytope.Polytope(POINTS=points_int)
 
         @test Base.propertynames(test_polytope) isa Base.Vector{Symbol}
         names = Base.propertynames(test_polytope)
@@ -102,30 +109,30 @@
         @test :VERTICES in names
         @test :FAR_FACE in names
         @test :GRAPH in names
-        @test test_polytope.GRAPH isa BigObject
+        @test test_polytope.GRAPH isa Polymake.BigObject
         @test allunique(Base.propertynames(test_polytope))
         g = test_polytope.GRAPH
         @test Base.propertynames(g) isa Base.Vector{Symbol}
     end
 
     @testset "save load" begin
-        test_polytope = @pm polytope.Polytope(input_dict_int)
+        test_polytope = @pm polytope.Polytope(POINTS=points_int)
         mktempdir() do path
             Polymake.save_bigobject(test_polytope,joinpath(path,"test.poly"))
             loaded = Polymake.load_bigobject(joinpath(path,"test.poly"))
-            @test loaded isa BigObject
+            @test loaded isa Polymake.BigObject
             @test Base.propertynames(test_polytope) == Base.propertynames(loaded)
         end
     end
 
     @testset "polymake tutorials" begin
-        p = @pm polytope.Polytope(:POINTS=>polytope.cube(4).VERTICES)
-        @test p isa BigObject
+        p = @pm polytope.Polytope(POINTS=polytope.cube(4).VERTICES)
+        @test p isa Polymake.BigObject
 
-        lp = @pm polytope.LinearProgram(:LINEAR_OBJECTIVE=>[0,1,1,1,1])
-        @test lp isa BigObject
+        lp = @pm polytope.LinearProgram(LINEAR_OBJECTIVE=[0,1,1,1,1])
+        @test lp isa Polymake.BigObject
 
-        @test (p.LP = lp) isa BigObject
+        @test (p.LP = lp) isa Polymake.BigObject
         @test p.LP.MAXIMAL_VALUE == 4
 
         matrix = Base.Rational{Int64}[
@@ -145,7 +152,7 @@
             1 1//16 1//16 1//4;
             1 1//4 1//16 1//16]
 
-        p = @pm polytope.Polytope(:POINTS=>matrix)
+        p = @pm polytope.Polytope(POINTS=matrix)
 
         @test polytope.dim(p) == 3
 
@@ -163,7 +170,7 @@
     end
 
     @testset "polymake MILP" begin
-        p = @pm polytope.Polytope( :INEQUALITIES => [1 1 -1; -1 0 1; 7 -1 -1] )
+        p = @pm polytope.Polytope( INEQUALITIES=[1 1 -1; -1 0 1; 7 -1 -1] )
         intvar = Polymake.Set([0,1,2])
         @test Polymake.convert(Polymake.PolymakeType, intvar) isa Polymake.Set{Polymake.to_cxx_type(Int64)}
 

--- a/test/tropicalnumber.jl
+++ b/test/tropicalnumber.jl
@@ -126,25 +126,25 @@
 
         @test one(ZEROmin) isa Polymake.TropicalNumber{Polymake.Min}
         @test zero(ZEROmin) isa Polymake.TropicalNumber{Polymake.Min}
-        @test dual_zero(ZEROmin) isa Polymake.TropicalNumber{Polymake.Min}
+        @test Polymake.dual_zero(ZEROmin) isa Polymake.TropicalNumber{Polymake.Min}
         @test one(Polymake.TropicalNumber{Polymake.Min}) isa Polymake.TropicalNumber{Polymake.Min}
         @test zero(Polymake.TropicalNumber{Polymake.Min}) isa Polymake.TropicalNumber{Polymake.Min}
-        @test dual_zero(Polymake.TropicalNumber{Polymake.Min}) isa Polymake.TropicalNumber{Polymake.Min}
+        @test Polymake.dual_zero(Polymake.TropicalNumber{Polymake.Min}) isa Polymake.TropicalNumber{Polymake.Min}
         @test one(ZEROmax) isa Polymake.TropicalNumber{Polymake.Max}
         @test zero(ZEROmax) isa Polymake.TropicalNumber{Polymake.Max}
-        @test dual_zero(ZEROmax) isa Polymake.TropicalNumber{Polymake.Max}
+        @test Polymake.dual_zero(ZEROmax) isa Polymake.TropicalNumber{Polymake.Max}
         @test one(Polymake.TropicalNumber{Polymake.Max}) isa Polymake.TropicalNumber{Polymake.Max}
         @test zero(Polymake.TropicalNumber{Polymake.Max}) isa Polymake.TropicalNumber{Polymake.Max}
-        @test dual_zero(Polymake.TropicalNumber{Polymake.Max}) isa Polymake.TropicalNumber{Polymake.Max}
+        @test Polymake.dual_zero(Polymake.TropicalNumber{Polymake.Max}) isa Polymake.TropicalNumber{Polymake.Max}
 
         @test zero(Polymake.TropicalNumber{Polymake.Min}) == zero(ONEmin) == ZEROmin
-        @test dual_zero(Polymake.TropicalNumber{Polymake.Min}) == dual_zero(ONEmin) == Polymake.TropicalNumber{Polymake.Min}(-Inf)
+        @test Polymake.dual_zero(Polymake.TropicalNumber{Polymake.Min}) == Polymake.dual_zero(ONEmin) == Polymake.TropicalNumber{Polymake.Min}(-Inf)
         @test one(Polymake.TropicalNumber{Polymake.Min}) == one(ZEROmin) == ONEmin
         @test zero(Polymake.TropicalNumber{Polymake.Max}) == zero(ONEmax) == ZEROmax
-        @test dual_zero(Polymake.TropicalNumber{Polymake.Max}) == dual_zero(ONEmax) == Polymake.TropicalNumber{Polymake.Max}(Inf)
+        @test Polymake.dual_zero(Polymake.TropicalNumber{Polymake.Max}) == Polymake.dual_zero(ONEmax) == Polymake.TropicalNumber{Polymake.Max}(Inf)
         @test one(Polymake.TropicalNumber{Polymake.Max}) == one(ZEROmax) == ONEmax
 
-        @test orientation(Polymake.TropicalNumber{Polymake.Min}) == orientation(ZEROmin) == -orientation(Polymake.TropicalNumber{Polymake.Max}) == - orientation(ZEROmax) == 1
+        @test Polymake.orientation(Polymake.TropicalNumber{Polymake.Min}) == Polymake.orientation(ZEROmin) == -Polymake.orientation(Polymake.TropicalNumber{Polymake.Max}) == - Polymake.orientation(ZEROmax) == 1
     end
 
     @testset "Promotion (equality)" begin


### PR DESCRIPTION
Updates README.md to the new syntax and bumps the version to `v0.3.0`

I added do not merge since it's better to 
- [x] merge @alexej-jordan types first and 
- [x] (maybe) get rid of all `pm_` prefixes
The last thing I'd definitely do it for `PerlObject`, `PropertyValue`, `OptionSet`), but `pm_Matrix` etc would have to be written as `Polymake.Matrix` etc, so people may have some opinions on this.
- [x] update to CxxWrap.jl 0.9.0
- [x] Fix options for visual #204 
- [x] Check and maybe bump binary dependencies (i.e. singularBuilder)