### PR TITLE
add function doc-text to json

### DIFF
--- a/deps/rules/apptojson.pl
+++ b/deps/rules/apptojson.pl
@@ -40,6 +40,7 @@ sub help_to_hash($$$) {
    # return \%fun if $ov->text eq "UNDOCUMENTED\n";
    my $ann = $ov->annex;
    $fun{name} = $help->name;
+   $fun{doc} = $ov->text;
    my $numparam = $ann->{param} ? scalar(@{$ann->{param}}) : 0;
    $fun{args} = [map { type_for_julia($appname,$_->[0]) } @{$ann->{param}}];
    $fun{mandatory} = defined $ann->{mandatory} ? $ann->{mandatory} + 1 : $numparam;


### PR DESCRIPTION
adds "doc" entry for functions and methods, fixes #192 

```json
    {
      "args" : [
        "Anything"
      ],
      "doc" : " Convert to a dense 0/1 matrix.\n",
      "mandatory" : 1,
      "name" : "dense",
      "return" : 1,
      "type_params" : 0
    },
```

so far the strings are unused