### PR TITLE
Fix sparsematrix test

### DIFF
--- a/deps/src/polymake_sparsematrix.cpp
+++ b/deps/src/polymake_sparsematrix.cpp
@@ -8,6 +8,11 @@
 
 void polymake_module_add_sparsematrix(jlcxx::Module& polymake)
 {
+
+    polymake
+        .add_type<pm::local_epsilon_keeper>("local_epsilon_keeper")
+        .constructor<double>();
+
     polymake
         .add_type<jlcxx::Parametric<jlcxx::TypeVar<1>>, jlcxx::ParameterList<jlcxx::TypeVar<1>,int>>(
             "SparseMatrix", jlcxx::julia_type("AbstractSparseMatrix", "SparseArrays"))

--- a/src/Polymake.jl
+++ b/src/Polymake.jl
@@ -84,6 +84,11 @@ function __init__()
         prepare_jupyter_kernel_for_visualization()
     end
 
+    # setting the local_epsilon_keeper for Float64 precision
+    # affects Polymake.SparseMatrix
+    global _pm_local_epsilon_keeper = Polymake.local_epsilon_keeper(eps(Float64)/2)
+
+
 end
 
 include("setup_apps.jl")

--- a/test/sparsematrix.jl
+++ b/test/sparsematrix.jl
@@ -390,7 +390,7 @@ using SparseArrays
     end
 
     @testset "findnz" begin
-        jsm = sprand(1015,1841,.14)
+        jsm = sprand(10150,1841,.001)
         psm = Polymake.SparseMatrix(jsm)
         jr, jc, jv = findnz(jsm)
         pr, pc, pv = findnz(psm)


### PR DESCRIPTION
by making `pm::local_epilson_keeper` accessible from julia we can adjust the precision of polymake. this fixes the flaky sparse matrix test where subnormal numbers were identified as zero.

to have this epsilon work, the instance with the desired value must exist. thats why i define the global variable `_pm_local_epsilon_keeper` in the `__init__()` method

This closes #196 