### PR TITLE
added support for global_epsilon and fixed sparsematrix test

### DIFF
--- a/deps/src/polymake_sparsematrix.cpp
+++ b/deps/src/polymake_sparsematrix.cpp
@@ -8,6 +8,9 @@
 
 void polymake_module_add_sparsematrix(jlcxx::Module& polymake)
 {
+
+    polymake.method("_get_global_epsilon", []() { return pm::spec_object_traits<double>::global_epsilon; });
+    polymake.method("_set_global_epsilon", [](double e) { pm::spec_object_traits<double>::global_epsilon = e; });
     polymake
         .add_type<jlcxx::Parametric<jlcxx::TypeVar<1>>, jlcxx::ParameterList<jlcxx::TypeVar<1>,int>>(
             "SparseMatrix", jlcxx::julia_type("AbstractSparseMatrix", "SparseArrays"))

--- a/test/sparsematrix.jl
+++ b/test/sparsematrix.jl
@@ -390,7 +390,8 @@ using SparseArrays
     end
 
     @testset "findnz" begin
-        jsm = sprand(1015,1841,.14)
+        jsm = sprand(1015,1841,.00014)
+        droptol!(jsm,Polymake._get_global_epsilon())
         psm = Polymake.SparseMatrix(jsm)
         jr, jc, jv = findnz(jsm)
         pr, pc, pv = findnz(psm)


### PR DESCRIPTION
as requested i added a method `_get_global_epsilon()`to ask for polymake's `global_epsilon` for doubles. additionally i included the method `_set_global_epsilon(e::Float64)` to alter this value. even though the latter is not used to fix the tests it might be useful some time.
the sparsematrix test is fixed by removing all entries smaller or equal to the global_epsilon within our julia sparse matrix (and implicitly adjusting the vectors returned by findnz) before generating the polymake sparse matrix from it

This closes #196 