### PR TITLE
Fix show for svg

### DIFF
--- a/src/visual.jl
+++ b/src/visual.jl
@@ -66,7 +66,7 @@ function Base.show(io::IO,::MIME"text/html",v::Visual)
     print(io,_get_visual_string_threejs(v))
 end
 
-function Base.show(io::IO,::MIME"text/svg+xml",v::Visual)
+function Base.show(io::IO,::MIME"image/svg+xml",v::Visual)
     print(io,_get_visual_string_svg(v))
 end
 


### PR DESCRIPTION
We had the wrong MIME type in the `show` definition.