### PR TITLE
Adjust Travis Test Matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,20 @@ julia:
   - 1.0
   - 1.2
   - 1.3
+  - 1.4
   - nightly
 matrix:
- allow_failures:
- - julia: nightly
+  exclude:
+  - julia: 1.0
+    os: osx
+  - julia: 1.2
+    os: osx
+  - julia: 1.4
+    os: osx
+  - julia: nightly
+    os: osx
+  allow_failures:
+  - julia: nightly
 notifications:
   email: false
 codecov: true


### PR DESCRIPTION
~~Everything on 1.3 should also work on 1.2. 1.4 has already a first release candidate, so we can use this on CI already~~
**Update:** Add 1.4 to the test matrix. Also exclude all mac jobs but for 1.3. Travis ci mac tests are really slow compared to linux (not much parallelism and slow scheduling).