### PR TITLE
add workaround for gcc 9 internal compiler error

### DIFF
--- a/deps/src/CMakeLists.txt
+++ b/deps/src/CMakeLists.txt
@@ -12,6 +12,14 @@ include_directories(${MY_LIST})
 SET( CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -std=c++14 ${polymake_cflags}" )
 SET( CMAKE_SHARED_LINKER_FLAGS  "${CMAKE_EXE_LINKER_FLAGS} ${polymake_ldflags}" )
 
+# avoid gcc 9 internal compiler error,
+# see https://gcc.gnu.org/bugzilla/show_bug.cgi?id=90998
+if(CMAKE_COMPILER_IS_GNUCC AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 9.0
+      AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 9.3)
+   SET( CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -Wno-conversion" )
+endif()
+
+
 file(GLOB polymake_SRC "*.cpp")
 add_library(polymake SHARED ${polymake_SRC})
 target_link_libraries(polymake JlCxx::cxxwrap_julia "${polymake_libs}")


### PR DESCRIPTION
added to cmake file instead of build.jl because the gcc version is readily available there and we dont have to parse it ourselves.

fixes #206 

see https://gcc.gnu.org/bugzilla/show_bug.cgi?id=90998

(in preparation for cxxwrap 0.9.0 as it triggers only when -std=c++17 is set)