### PR TITLE
fix for mac os cxxlong issue

### DIFF
--- a/deps/src/polymake_rationals.cpp
+++ b/deps/src/polymake_rationals.cpp
@@ -16,8 +16,8 @@ void polymake_module_add_rational(jlcxx::Module& polymake)
                                 jlcxx::julia_type("Real", "Base"))
         .constructor<pm::Integer, pm::Integer>()
         .method("rational_si_si", [](
-            const jlcxx::StrictlyTypedNumber<int64_t>& num,
-            const jlcxx::StrictlyTypedNumber<int64_t>& den) {
+            const jlcxx::StrictlyTypedNumber<long>& num,
+            const jlcxx::StrictlyTypedNumber<long>& den) {
             return pm::Rational(num.value, den.value);
         })
         .method("<", [](pm::Rational& a, pm::Rational& b) { return a < b; })


### PR DESCRIPTION
Since `CxxLong` is defined explicitly as `long` in `libcxxwrap-julia`, see [here](https://github.com/JuliaInterop/libcxxwrap-julia/blob/6fd4bd0150fb3551f76f8f6f7b26f4d57dcaefb9/src/jlcxx.cpp#L380), we should probably use it like that, 

Successful travis build: https://travis-ci.com/oscar-system/Polymake.jl/jobs/284762142