### PR TITLE
Add bit operations for Integers

### DIFF
--- a/src/integers.jl
+++ b/src/integers.jl
@@ -46,3 +46,8 @@ Base.float(int::Integer) = Float64(int)
 # no-copy converts
 convert(::Type{<:Integer}, int::T) where T <: Integer = int
 convert(::Type{Base.Integer}, int::Integer) = int
+
+Base.trailing_zeros(int::Integer) = trailing_zeros(BigInt(int))
+Base.trailing_ones(int::Integer) = trailing_ones(BigInt(int))
+Base.:(>>)(int::Polymake.Integer, n::UInt64) = >>(BigInt(int), n)
+Base.:(<<)(int::Polymake.Integer, n::UInt64) = <<(BigInt(int), n)

--- a/test/integers.jl
+++ b/test/integers.jl
@@ -79,4 +79,13 @@
         @test zero(Polymake.Integer) == zero(ONE) == ZERO
         @test one(Polymake.Integer) == one(ZERO) == ONE
     end
+
+    @testset "Fun with bits" begin
+        @test trailing_zeros(Polymake.Integer(2)) == 1
+        @test trailing_zeros(Polymake.Integer(4)) == 2
+        @test trailing_ones(Polymake.Integer(2)) == 0
+        @test trailing_ones(Polymake.Integer(3)) == 2
+        @test Polymake.Integer(1) << 2 == 4
+        @test Polymake.Integer(4) >> 2 == 1
+    end
 end


### PR DESCRIPTION
These are used in the generic `power_by_squaring` method in Julia.

I guess the bit shift is defined in polymake, but I couldn't find it, so I just went with the lazy version.