### PR TITLE
fix #251: adjust ostringstream constructor for recent libstdc++

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Polymake"
 uuid = "d720cf60-89b5-51f5-aff5-213f193123e7"
 repo = "https://github.com/oscar-system/Polymake.jl.git"
-version = "0.3.2"
+version = "0.3.3"
 
 [deps]
 BinaryProvider = "b99e7846-7c00-51b0-8f62-c81ae34c0232"

--- a/deps/src/polymake_functions.h
+++ b/deps/src/polymake_functions.h
@@ -20,7 +20,7 @@ pm::Integer new_integer_from_bigint(jl_value_t*);
 template <typename T>
 std::string show_small_object(const T& obj, bool print_typename = true)
 {
-    std::ostringstream buffer;
+    std::ostringstream buffer("");
     auto               wrapped_buffer = wrap(buffer);
     if (print_typename) {
         wrapped_buffer << polymake::legible_typename(typeid(obj)) << pm::endl;


### PR DESCRIPTION
Better fix this time, just 4 characters. As it turns out, only the default constructor for ostringstream requires `GLIBCXX_3.4.26`, we can just use an empty string instead.

---- obsolete first try:
@fingolfin @kalmarek 

Unfortunately just dlopening a new `libstdc++.so.6.0.26` doesn't help because the `DT_NEEDED` of `libpolymake.so` is just `libstdc++.so.6` which will still resolve to the old one from julia which is also in memory.

But since we love having more and more dependencies we can patch the library with `patchelf` to use the full filename of the correct `libstdc++`. I tried looking for options to gcc to do something similar at link time but that seems impossible.

PS: all of the above applies only to Sys.islinux()