### PR TITLE
Travis: simplify config, add Xcode 11.4 test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: julia
 dist: bionic
 os:
   - linux
-  - osx
 julia:
   - 1.0
   - 1.2
@@ -11,14 +10,8 @@ julia:
   - 1.4
   - nightly
 matrix:
-  exclude:
-  - julia: 1.0
-    os: osx
-  - julia: 1.2
-    os: osx
-  - julia: 1.4
-    os: osx
-  - julia: nightly
+  include:
+  - julia: 1.3
     os: osx
   allow_failures:
   - julia: nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,14 @@ matrix:
   include:
   - julia: 1.3
     os: osx
+  - julia: 1.4
+    os: osx
+    osx_image: xcode11.4
   allow_failures:
   - julia: nightly
+  - julia: 1.4
+    os: osx
+    osx_image: xcode11.4
 notifications:
   email: false
 codecov: true


### PR DESCRIPTION
The test with Xcode 11.4 of course fails (see https://github.com/oscar-system/Oscar.jl/issues/82)