### PR TITLE
suppress welcome messages

### DIFF
--- a/src/Polymake.jl
+++ b/src/Polymake.jl
@@ -64,13 +64,8 @@ function __init__()
     end
 
     try
-        show_banner = isinteractive() &&
-                       !any(x->x.name in ["Oscar"], keys(Base.package_locks))
-
-        initialize_polymake(show_banner)
-        if !show_banner
-            shell_execute(raw"$Verbose::credits=\"0\";")
-        end
+        initialize_polymake(false)
+        shell_execute(raw"$Verbose::credits=\"0\";")
     catch ex # initialize_polymake throws jl_error
         throw(PolymakeError(ex.msg))
     end


### PR DESCRIPTION
As was also commented in Nemocas/Nemo.jl#817 and [Julia discourse](https://discourse.julialang.org/t/redirecting-stdout-to-avoid-banners-while-import-ing/37633), printing welcome messages upon module import is unusual behavior for Julia modules and quickly becomes unwieldy.   Can this please be omitted?