### PR TITLE
Simplify GitHub actions CI matrix

### DIFF
--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -14,18 +14,14 @@ jobs:
     strategy:
       matrix:
         julia-version: ['1.3', '1.4', 'nightly']
-        os: [ubuntu-latest, macOS-latest]
+        os: ubuntu-latest
         # empty entry for defaults
         xcode: [ '' ]
         cxxwrap: [ '' ]
-        exclude:
-        # only julia 1.4 on macOS
-          - os: macos-latest
-            julia-version: 'nightly'
-          - os: macos-latest
-            julia-version: '1.3'
         # add a few extra tests
         include:
+          - os: macos-latest
+            julia-version: 1.4
           - xcode: '11.4'
             os: macos-latest
             julia-version: 1.4


### PR DESCRIPTION
Instead of adding three macOS jobs, then removing two of them, it seems
conceptually simpler to just ad the remaining one explicitly.