### PR TITLE
fix/adjust signal handling

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -116,6 +116,10 @@ If you already have a polymake installation you need to set the environment vari
     eval(depsjl)
     prepare_env()
     run(`$perl -pi -e "s{REPLACEPREFIX}{$pm_bin_prefix}g" $pm_config $pm_config_ninja $polymake`)
+
+    # adjust signal used for initalization purposes to avoid problems
+    run(`$perl -pi -e "s/SIG{INT}/SIG{USR1}/g" $pm_bin_prefix/share/polymake/perllib/Polymake/Main.pm`)
+
     run(`sh -c "$perl -pi -e 's{/workspace/destdir}{$pm_bin_prefix}g' $pm_bin_prefix/lib/perl5/*/*/Config_heavy.pl"`)
 
 else

--- a/deps/src/polymake_functions.cpp
+++ b/deps/src/polymake_functions.cpp
@@ -12,7 +12,6 @@ void initialize_polymake(bool interactive = true)
         if (data.main_polymake_session == nullptr) {
             data.main_polymake_session = new polymake::Main;
             data.main_polymake_session->shell_enable();
-            data.main_polymake_session->set_interrupt_signal(SIGINT);
             data.main_polymake_scope = new polymake::Scope(
                 data.main_polymake_session->newScope());
             if (interactive){

--- a/src/perlobj.jl
+++ b/src/perlobj.jl
@@ -43,7 +43,7 @@ function give(obj::BigObject, prop::String)
         ex isa ErrorException && throw(PolymakeError(ex.msg))
         if (ex isa InterruptException)
             @warn("""Interrupting polymake is not safe.
-                   You are entering the dark forest of memory corruption in the valley segfaults, bring your 🏹, ⚔︎ and 🛡︎.
+                   You are entering the dark forest of memory corruption in the valley of segfaults, bring your 🏹, ⚔︎ and 🛡︎.
                    Please restart your julia session if you encounter any weird stuff.""")
         end
         rethrow(ex)

--- a/src/perlobj.jl
+++ b/src/perlobj.jl
@@ -41,6 +41,11 @@ function give(obj::BigObject, prop::String)
         internal_give(obj, prop)
     catch ex
         ex isa ErrorException && throw(PolymakeError(ex.msg))
+        if (ex isa InterruptException)
+            @warn("""Interrupting polymake is not safe.
+                   You are entering the dark forest of memory corruption in the valley segfaults, bring your 🏹, ⚔︎ and 🛡︎.
+                   Please restart your julia session if you encounter any weird stuff.""")
+        end
         rethrow(ex)
     end
     return convert_from_property_value(return_obj)


### PR DESCRIPTION
This contains:
- [x] dont capture sigint from polymake (as it completely blocks it for julia)
- [x] use different signal for initalization of polymake Main.pm (otherwise julia terminates instantly on ctrl+c)
- [x] warn on ctrl+c during polymake computation

Fixes #233

Further ideas:
- [ ] Maybe we could add a similar warning for `polymake_call_function`.
- [ ] We should get julia to not interrupt polymake but that doesn't seem feasible at the moment.

Currently behaves like this, including the segfault during exit (when Ctrl+C was used to abort polymake at some point):
```julia
julia> using Polymake
polymake version 4.0
Copyright (c) 1997-2020
Ewgenij Gawrilow, Michael Joswig, and the polymake team
Technische Universität Berlin, Germany
https://polymake.org

This is free software licensed under GPL; see the source for copying conditions.
There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.


julia> s = polytope.rand_sphere(15, 1000);

julia> s.VERTICES
^C┌ Warning: Interrupting polymake is not safe.
│ You are entering the dark forest of memory corruption in the valley segfaults, bring your 🏹, ⚔︎ and 🛡︎.
│ Please restart your julia session if you encounter any weird stuff.
└ @ Polymake ~/software/polymake/julia/Polymake-glibcxx.jl/src/perlobj.jl:45
ERROR: InterruptException:
Stacktrace:
 [1] internal_give(::Polymake.BigObjectAllocated, ::String) at /home/lorenz/.julia/packages/CxxWrap/LfTHV/src/CxxWrap.jl:597
 [2] give(::Polymake.BigObjectAllocated, ::String) at /home/lorenz/software/polymake/julia/Polymake-glibcxx.jl/src/perlobj.jl:41
 [3] getproperty(::Polymake.BigObjectAllocated, ::Symbol) at /home/lorenz/software/polymake/julia/Polymake-glibcxx.jl/src/perlobj.jl:58

julia> exit()

signal (11): Segmentation fault
in expression starting at REPL[5]:0
Segmentation fault
```