### PR TITLE
Function docs2

### DIFF
--- a/deps/rules/apptojson.pl
+++ b/deps/rules/apptojson.pl
@@ -40,6 +40,7 @@ sub help_to_hash($$$) {
    # return \%fun if $ov->text eq "UNDOCUMENTED\n";
    my $ann = $ov->annex;
    $fun{name} = $help->name;
+   $fun{doc} = $ov->text;
    my $numparam = $ann->{param} ? scalar(@{$ann->{param}}) : 0;
    $fun{args} = [map { type_for_julia($appname,$_->[0]) } @{$ann->{param}}];
    $fun{mandatory} = defined $ann->{mandatory} ? $ann->{mandatory} + 1 : $numparam;


### PR DESCRIPTION
supersedes #199 

old behaviour:
```julia
help?> polytope.dim
  No documentation found.

  Polymake.polytope.dim is a Function.

  # 2 methods for generic function "dim":
  [1] dim(::Type{Polymake.PropertyValue}, object::Polymake.BigObject, args...; kwargs...) in Polymake.polytope at /home/kalmar/.julia/dev/Polymake/src/meta.jl:289
  [2] dim(object::Polymake.BigObject, args...; kwargs...) in Polymake.polytope at /home/kalmar/.julia/dev/Polymake/src/meta.jl:294

```
new behaviour:
```julia
help?> polytope.dim
 returns the geometric dimension of the cone (including the lineality space)
 for the dimension of the pointed part ask for [[COMBINATORIAL_DIM]]

 ---- 
 returns the dimension of the polytope

 ---- 
 Affine dimension of the point configuration.
 Similar to [[Polytope::DIM]].

```