### PR TITLE
Bump version to v0.4.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Polymake"
 uuid = "d720cf60-89b5-51f5-aff5-213f193123e7"
 repo = "https://github.com/oscar-system/Polymake.jl.git"
-version = "0.4.0"
+version = "0.4.1"
 
 [deps]
 BinaryProvider = "b99e7846-7c00-51b0-8f62-c81ae34c0232"


### PR DESCRIPTION
I would really like to have a release with the Xcode 11.4 fix. Is there something holding this bacK?