### PR TITLE
json docs: add more information for functions and also full polymake-style text (fix #269)

### DIFF
--- a/deps/rules/apptojson.pl
+++ b/deps/rules/apptojson.pl
@@ -156,8 +156,8 @@ sub app_to_json($$) {
                                    };
       }
 
-      $objhash->{mandatory_params} = $ann->{mandatory_tparam}
-         if defined($ann) && defined($ann->{mandatory_tparam});
+      $objhash->{mandatory_params} = $ann->{mandatory_tparams}
+         if defined($ann) && defined($ann->{mandatory_tparams});
 
       $objhash->{linear_isa} = [
                                   map { $_->qualified_name }

--- a/deps/rules/apptojson.pl
+++ b/deps/rules/apptojson.pl
@@ -40,16 +40,57 @@ sub help_to_hash($$$) {
    # return \%fun if $ov->text eq "UNDOCUMENTED\n";
    my $ann = $ov->annex;
    $fun{name} = $help->name;
-   $fun{doc} = $ov->text;
+   $fun{description} = $ov->text;
+   my $textdoc = true;
    my $numparam = $ann->{param} ? scalar(@{$ann->{param}}) : 0;
-   $fun{args} = [map { type_for_julia($appname,$_->[0]) } @{$ann->{param}}];
+   foreach my $arg (@{$ann->{param}}) {
+      push @{$fun{args}}, {
+                             name => $arg->name,
+                             type => type_for_julia($appname,$arg->type,$ann->{tparam}),
+                             description => $arg->text
+                           };
+   }
    $fun{mandatory} = defined $ann->{mandatory} ? $ann->{mandatory} + 1 : $numparam;
-   push @{$fun{args}}, ("Anything") x ($fun{mandatory} - $numparam)
-      if $fun{mandatory} > $numparam;
-   $fun{type_params} = defined $ann->{tparam} ? scalar(@{$ann->{tparam}}) : 0;
+
+   if ($fun{mandatory} > $numparam) {
+      push @{$fun{args}}, ({name => "",type=>"Anything",description=>""})
+                           x ($fun{mandatory} - $numparam);
+      $textdoc = false;
+   }
+
+   $fun{type_params} = [ map { {name=>$_->name, type=>"", description=>$_->text} } @{$ann->{tparam}}]
+      if defined $ann->{tparam};
+
    # not needed $fun{include} = ;
-   push @{$fun{args}}, "OptionSet" if defined $ann->{options};
-   $fun{return} = $help->return_type if defined($help->return_type);
+   if (defined ($ann->{options}) && scalar($ann->{options}) > 0) {
+      push @{$fun{args}}, {name => "options", type => "OptionSet", description=>""};
+      push @{$fun{opts}},
+         map {
+            {
+               name => $_->name,
+               type => type_for_julia($appname,$_->type,$ann->{tparam}),
+               description=> $_->text
+            }
+         }
+         @{$ann->{options}[0]->annex->{keys}};
+   }
+
+   $fun{examples} = [ map {$_->body} @{$ann->{examples}} ]
+      if defined $ann->{examples};
+
+   $fun{return} = {type => type_for_julia($appname,$ann->{return}->type,$ann->{tparam}), description=>$ann->{return}->text}
+      if defined($ann->{return});
+
+   if ($textdoc) {
+      my $text_writer = new Core::Help::PlainText(0);
+      $ov->write_function_text($help, $text_writer, true);
+      $fun{doc} = $text_writer->text;
+   } else {
+      # this is necessary due to a bug in polymake
+      $fun{doc} = "";
+      print STDERR "WARNING: skipping text docs for ",$help->name,"\n";
+   }
+
    return \%fun;
 }
 


### PR DESCRIPTION
I have put the full text into the `doc` entry so we automatically get the full text as help back.
That is until we build our own docstring from the other data that is now available in the json but mostly unused.

Also contains the same info for methods, indicated with `method_of` key that we already use in some places.

But I guess while I am at it I should also add more information about the parameters to the json for the big object types, so just a draft for now.

```
help?> polytope.rand_sphere
rand_sphere<Num>(d, n; Options) -> Polytope<Rational>

 Produce a rational d-dimensional polytope with n random vertices
 approximately uniformly distributed on the unit sphere.

Type Parameters:
  Num can be AccurateFloat (the default) or Rational
    With AccurateFloat the distribution should be closer to uniform,
    but the vertices will not exactly be on the sphere.
    With Rational the vertices are guaranteed to be on the unit sphere,
    at the expense of both uniformity and log-height of points.

Arguments:
  Int d the dimension of sphere
  Int n the number of random vertices

Options: 
  seed => Int controls the outcome of the random number generator;
    fixing a seed number guarantees the same outcome. 
  precision => Int Number of bits for MPFR sphere approximation

Returns Polytope<Rational> 
```

for the above we have now:
```json
    {
      "args" : [
        {
          "description" : "the dimension of sphere\n",
          "name" : "d",
          "type" : "Int"
        },
        {
          "description" : "the number of random vertices\n",
          "name" : "n",
          "type" : "Int"
        },
        {
          "description" : "",
          "name" : "options",
          "type" : "OptionSet"
        }
      ],
      "description" : " Produce a rational //d//-dimensional polytope with //n// random vertices\n approximately uniformly distributed on the unit sphere.\n",
      "doc" : "rand_sphere<Num>(d, n; Options) -> Polytope<Rational>\n\n Produce a rational \u001b[4md\u001b[24m-dimensional polytope with \u001b[4mn\u001b[24m random vertices\n approximately uniformly distributed on the unit sphere.\n\nType Parameters:\n  Num can be AccurateFloat (the default) or Rational\n    With \u001b[4mAccurateFloat\u001b[24m the distribution should be closer to uniform,\n    but the vertices will not exactly be on the sphere.\n    With \u001b[4mRational\u001b[24m the vertices are guaranteed to be on the unit sphere,\n    at the expense of both uniformity and log-height of points.\n\nArguments:\n  Int d the dimension of sphere\n  Int n the number of random vertices\n\nOptions: \n  seed => Int controls the outcome of the random number generator;\n    fixing a seed number guarantees the same outcome. \n  precision => Int Number of bits for MPFR sphere approximation\n\nReturns Polytope<Rational> \n",
      "mandatory" : 2,
      "name" : "rand_sphere",
      "opts" : [
        {
          "description" : "controls the outcome of the random number generator;\n   fixing a seed number guarantees the same outcome. \n",
          "name" : "seed",
          "type" : "Int"
        },
        {
          "description" : "Number of bits for MPFR sphere approximation\n",
          "name" : "precision",
          "type" : "Int"
        }
      ],
      "return" : {
        "description" : "",
        "type" : "BigObject<Polytope>"
      },
      "type_params" : [
        {
          "description" : "can be AccurateFloat (the default) or Rational\n With [[AccurateFloat]] the distribution should be closer to uniform,\n but the vertices will not exactly be on the sphere.\n With [[Rational]] the vertices are guaranteed to be on the unit sphere,\n at the expense of both uniformity and log-height of points.\n",
          "name" : "Num",
          "type" : ""
        }
      ]
    },
```
