### PR TITLE
Fix/startup error

### DIFF
--- a/src/Polymake.jl
+++ b/src/Polymake.jl
@@ -87,8 +87,9 @@ function __init__()
         if !show_banner
             shell_execute(raw"$Verbose::credits=\"0\";")
         end
-    catch ex # initialize_polymake throws jl_error
-        throw(PolymakeError(ex.msg))
+    catch ex # initialize_polymake may throw jl_error
+        ex isa ErrorException && throw(PolymakeError(ex.msg))
+        rethrow(ex)
     end
 
     application("common")

--- a/src/polymake_direct_calls.jl
+++ b/src/polymake_direct_calls.jl
@@ -23,6 +23,6 @@ for (pm_solve_LP, scalarT, concreteT) in [
     end
 end
 
-solve_LP(inequalities::AbstractMatrix{T}, objective::AbstractVector; sense=max) where T = solve_LP(inequalities, Matrix{T}(undef, 0, 0), objective, sense)
+solve_LP(inequalities::AbstractMatrix{T}, objective::AbstractVector; sense=max) where T = solve_LP(inequalities, Base.Matrix{T}(undef, 0, 0), objective, sense)
 
 solve_LP(inequalities::AbstractMatrix, equalities::AbstractMatrix, objective::AbstractVector; sense=max) = solve_LP(inequalities, equalities, objective, sense)

--- a/src/util.jl
+++ b/src/util.jl
@@ -29,8 +29,8 @@ function shell_execute(str::AbstractString)
     end
 end
 
-const version = VersionNumber(shell_execute("print \$Version;").stdout)
-const installTop = shell_execute("print \$InstallTop;").stdout
+version() = VersionNumber(shell_execute("print \$Version;").stdout)
+installTop() = shell_execute("print \$InstallTop;").stdout
 
 function cite(;format=:bibtex)
     cite_str = match(r"(?<bibtex>@incollection.*\n (\s*\w*\s?= .*\n)+\s*\})", shell_execute("""help "core/citation";""").stdout)

--- a/src/util.jl
+++ b/src/util.jl
@@ -29,6 +29,9 @@ function shell_execute(str::AbstractString)
     end
 end
 
+const version = VersionNumber(shell_execute("print \$Version;").stdout)
+const installTop = shell_execute("print \$InstallTop;").stdout
+
 function cite(;format=:bibtex)
     cite_str = match(r"(?<bibtex>@incollection.*\n (\s*\w*\s?= .*\n)+\s*\})", shell_execute("""help "core/citation";""").stdout)
     if format == :bibtex


### PR DESCRIPTION
I crammed three small things here:

* proper error catching during polymake init (occasionally handling resulted in another exception thrown, where thrown exception had no `.msg` (e.g. when it was not actually thrown from withing polymake)
* add `Polymake.version` and `Polymake.installTop` constants (why the latter name? wouldn't `install_prefix` be better? @benlorenz )
* a missing distinction between `BaseMatrix` vs `Polymake.Matrix` in `direct_calls`