### PR TITLE
disable_sigint() around internal_calls and internal_give

### DIFF
--- a/src/call_function.jl
+++ b/src/call_function.jl
@@ -16,7 +16,9 @@ function call_function(::Type{PropertyValue}, app::Symbol, func::Symbol, args...
     fname = Meta.pm_name_qualified(app, func)
     cargs = Meta.polymake_arguments(args...; kwargs...)
     templ = CxxWrap.StdVector{CxxWrap.StdString}(template_parameters)
-    return internal_call_function(fname, templ, cargs)
+    return disable_sigint() do
+        internal_call_function(fname, templ, cargs)
+    end
 end
 
 function call_function(app::Symbol, func::Symbol, args...;
@@ -40,7 +42,9 @@ function call_method(::Type{PropertyValue}, obj::BigObject, func::Symbol, args..
     kwargs...)
     fname = string(func)
     cargs = Meta.polymake_arguments(args...; kwargs...)
-    return internal_call_method(fname, obj, cargs)
+    return disable_sigint() do
+        internal_call_method(fname, obj, cargs)
+    end
 end
 
 function call_method(obj::BigObject, func::Symbol, args...; kwargs...)

--- a/src/perlobj.jl
+++ b/src/perlobj.jl
@@ -38,7 +38,9 @@ Base.setproperty!(obj::BigObject, prop::String, val) = setproperty!(obj, Symbol(
 
 function give(obj::BigObject, prop::String)
     return_obj = try
-        internal_give(obj, prop)
+        disable_sigint() do
+            internal_give(obj, prop)
+        end
     catch ex
         ex isa ErrorException && throw(PolymakeError(ex.msg))
         if (ex isa InterruptException)

--- a/src/perlobj.jl
+++ b/src/perlobj.jl
@@ -44,9 +44,8 @@ function give(obj::BigObject, prop::String)
     catch ex
         ex isa ErrorException && throw(PolymakeError(ex.msg))
         if (ex isa InterruptException)
-            @warn("""Interrupting polymake is not safe.
-                   You are entering the dark forest of memory corruption in the valley of segfaults, bring your 🏹, ⚔︎ and 🛡︎.
-                   Please restart your julia session if you encounter any weird stuff.""")
+            @warn """Interrupting polymake is not safe.
+            SIGINT is disabled while waiting for polymake to finish its computations."""
         end
         rethrow(ex)
     end


### PR DESCRIPTION
we still print scary warning in give, but: 
```julia
julia> c = polytope.cube(14); v = c.VERTICES;
^C┌ Warning: Interrupting polymake is not safe.
│ You are entering the dark forest of memory corruption in the valley of segfaults, bring your 🏹, ⚔︎ and 🛡︎.
│ Please restart your julia session if you encounter any weird stuff.
└ @ Polymake ~/.julia/dev/Polymake/src/perlobj.jl:47
ERROR: InterruptException:
Stacktrace:
 [1] sigatomic_end at ./c.jl:425 [inlined]
 [2] disable_sigint at ./c.jl:448 [inlined]
 [3] give(::Polymake.BigObjectAllocated, ::String) at /home/kalmar/.julia/dev/Polymake/src/perlobj.jl:41
 [4] getproperty(::Polymake.BigObjectAllocated, ::Symbol) at /home/kalmar/.julia/dev/Polymake/src/perlobj.jl:60
 [5] top-level scope at REPL[11]:1

julia> exit()
```
no crash at the end. I'm not sure if the warning (however cute) should stay. Should we maybe say:
```julia
@warn """Interrupting polymake is not safe. 
         Sigint is disabled while waiting for polymake to finish its computations."""
```
?
(it's a pitty that the warning is printed only after polymake has returned...)