### PR TITLE
Adjust error message when Polymake needs to be re-built

### DIFF
--- a/src/Polymake.jl
+++ b/src/Polymake.jl
@@ -55,7 +55,7 @@ deps_dir = joinpath(@__DIR__, "..", "deps")
 
 isfile(joinpath(deps_dir,"jlcxx_version.jl")) &&
     isfile(joinpath(deps_dir,"deps.jl")) ||
-    error("""Please run `using Pkg; Pkg.build("Polymake");`""")
+    error("""Please run `using Pkg; Pkg.add("Polymake"); Pkg.build("Polymake");`""")
 
 include(joinpath(deps_dir,"jlcxx_version.jl"))
 


### PR DESCRIPTION
Doing `Pkg.build("Polymake")` alone will not work in general; e.g. if
the user only installed Polymake indirectly via `Pkg.add("Oscar")`.