### PR TITLE
function parameters

### DIFF
--- a/deps/rules/apptojson.pl
+++ b/deps/rules/apptojson.pl
@@ -50,16 +50,19 @@ sub help_to_hash($$$) {
                              description => $arg->text
                            };
    }
-   $fun{mandatory} = defined $ann->{mandatory} ? $ann->{mandatory} + 1 : $numparam;
+   $fun{mandatory_args} = defined $ann->{mandatory} ? $ann->{mandatory} + 1 : $numparam;
 
-   if ($fun{mandatory} > $numparam) {
+   if ($fun{mandatory_args} > $numparam) {
       push @{$fun{args}}, ({name => "",type=>"Anything",description=>""})
-                           x ($fun{mandatory} - $numparam);
+                           x ($fun{mandatory_args} - $numparam);
       $textdoc = false;
    }
 
    $fun{type_params} = [ map { {name=>$_->name, type=>"", description=>$_->text} } @{$ann->{tparam}}]
       if defined $ann->{tparam};
+
+   $fun{mandatory_type_params} = $ann->{mandatory_tparams}
+      if defined($ann->{mandatory_tparams});
 
    # not needed $fun{include} = ;
    if (defined ($ann->{options}) && scalar($ann->{options}) > 0) {
@@ -142,11 +145,11 @@ sub app_to_json($$) {
       my $ann = $type->help->annex;
       my $objhash = {
                        name => $type->full_name,
-                       help => $type->help->display_text
+                       doc => $type->help->display_text
                     };
       my $c = 0;
       foreach my $p (@{$type->params // [] }) {
-         push @{$objhash->{params}}, {
+         push @{$objhash->{type_params}}, {
                                       name => $p->name,
                                       description =>
                                           defined($ann->{tparam})
@@ -156,7 +159,7 @@ sub app_to_json($$) {
                                    };
       }
 
-      $objhash->{mandatory_params} = $ann->{mandatory_tparams}
+      $objhash->{mandatory_type_params} = $ann->{mandatory_tparams}
          if defined($ann) && defined($ann->{mandatory_tparams});
 
       $objhash->{linear_isa} = [

--- a/src/meta.jl
+++ b/src/meta.jl
@@ -265,29 +265,85 @@ end
 
 ########## code generation
 
+function jl_function(callable::Symbol,
+                     jl_name::Symbol,
+                     pm_name::String,
+                     app_name::String)
+    return quote
+        function $(jl_name)(::Type{PropertyValue}, args...;
+            template_parameters::Base.AbstractVector{<:AbstractString}=String[],
+            kwargs...)
+            return $(callable)(PropertyValue, Symbol($app_name), Symbol($pm_name), args...;
+                template_parameters=template_parameters, kwargs...)
+        end;
+        function $(jl_name)(args...;
+            template_parameters::Base.AbstractVector{<:AbstractString}=String[],
+            kwargs...)
+            return $(callable)(Symbol($app_name), Symbol($pm_name), args...;
+                template_parameters=template_parameters, kwargs...)
+        end;
+    end
+end
+
+function jl_function(callable::Symbol,
+                     jl_name::Symbol,
+                     pm_name::String,
+                     app_name::String,
+                     templates)
+    return quote
+        function $(jl_name){$(templates...)}(::Type{PropertyValue},
+            args...;
+            kwargs...) where {$(templates...)}
+            template_parameters = translate_type_to_pm_string.([$(templates...)])
+            return $(callable)(PropertyValue, Symbol($app_name), Symbol($pm_name), args...;
+                template_parameters=template_parameters, kwargs...)
+        end
+        function $(jl_name){$(templates...)}(args...; kwargs...) where {$(templates...)}
+            template_parameters = translate_type_to_pm_string.([$(templates...)])
+            return $(callable)(Symbol($app_name), Symbol($pm_name), args...;
+                template_parameters=template_parameters, kwargs...)
+        end
+    end
+end
+
+jl_function(pf::PolymakeFunction, templates) =
+    jl_function(callable(pf), jl_symbol(pf), pm_name(pf), pm_app(pf), templates)
+
+jl_function(pf::PolymakeFunction) =
+    jl_function(callable(pf), jl_symbol(pf), pm_name(pf), pm_app(pf))
+
 function jl_code(pf::PolymakeFunction, doc_string=docstring(pf))
     jlfunc_name = jl_symbol(pf)
     func_name = pm_name(pf)
     app = pm_app(pf)
+    min_tparam = mandatorytemplates(pf)
+
+    if istemplated(pf)
+        tparams = Symbol.(map(x->get(x,"name",String),templates(pf)))
+        templated_functions= [
+            jl_function(pf, tparams[1:i])
+               for i in max(min_tparam,1):length(tparams)
+        ]
+
+        functiondef = quote
+            struct $(jlfunc_name){$(tparams...)}
+               $(templated_functions...)
+               $(if min_tparam == 0
+                  jl_function(pf)
+                 end)
+            end;
+        end # of quote
+    else
+        functiondef = quote
+            struct $(jlfunc_name)
+                $(jl_function(pf))
+            end;
+        end # of quote
+    end
 
     return quote
-        function $(jlfunc_name)(::Type{PropertyValue}, args...;
-            template_parameters::Base.AbstractVector{<:AbstractString}=String[],
-            kwargs...)
-
-            return $(callable(pf))(PropertyValue, Symbol($app), Symbol($func_name), args...;
-                template_parameters=template_parameters, kwargs...)
-        end;
-        function $(jlfunc_name)(args...;
-            template_parameters::Base.AbstractVector{<:AbstractString}=String[],
-            kwargs...)
-
-            return $(callable(pf))(Symbol($app), Symbol($func_name), args...;
-                template_parameters=template_parameters, kwargs...)
-        end;
-        function $(Base.Docs).getdoc(::typeof($(jlfunc_name)))
-            return PolymakeDocstring($(doc_string))
-        end;
+        $functiondef
+        Base.Docs.getdoc(::Type{$(jlfunc_name)}) = PolymakeDocstring($(doc_string))
         export $(jlfunc_name);
     end
 end
@@ -295,6 +351,7 @@ end
 function jl_code(pm::PolymakeMethod, doc_string = docstring(pm))
     jlfunc_name = jl_symbol(pm)
     func_name = pm_name(pm)
+    # note that polymake methods cannot have explicit template parameters, so no need to deal with that here
     return quote
         function $(jlfunc_name)(::Type{PropertyValue}, object::BigObject,
             args...; kwargs...)

--- a/src/meta.jl
+++ b/src/meta.jl
@@ -265,6 +265,15 @@ end
 
 ########## code generation
 
+function jl_missing_type(jl_name::Symbol,type_names::Array{Symbol})
+    sig = QuoteNode("$jl_name{$(join(type_names,","))}")
+    return quote
+        $(jl_name)(args...; kwargs...) =
+            throw(ArgumentError("Missing type parameter(s) for `$($sig)(...)` ."))
+    end
+end
+
+
 function jl_function(callable::Symbol,
                      jl_name::Symbol,
                      pm_name::String,
@@ -330,6 +339,8 @@ function jl_code(pf::PolymakeFunction, doc_string=docstring(pf))
                $(templated_functions...)
                $(if min_tparam == 0
                   jl_function(pf)
+                 else
+                  jl_missing_type(jlfunc_name,tparams[1:min_tparam])
                  end)
             end;
         end # of quote
@@ -415,6 +426,8 @@ function jl_code(obj::PolymakeObject)
                 # inner template-less constructor
                 $(if mand == 0
                    jl_constructor(obj)
+                  else
+                   jl_missing_type(jl_object_name,Ts[1:mand])
                   end)
             end;
         end # of quote

--- a/src/meta.jl
+++ b/src/meta.jl
@@ -238,10 +238,9 @@ callable(::PolymakeMethod) = :call_method
 
 docstring(pc::PolymakeCallable) = get(pc.json, "doc", "")
 
-docstring(obj::PolymakeObject) = get(obj.json, "help", "")
-istemplated(obj::PolymakeObject) = haskey(obj.json, "params")
-mandatorytemplates(obj::PolymakeObject) = get(obj.json, "mandatory_params", 0)
-templates(obj::PolymakeObject) = get(obj.json, "params", Dict[])
+istemplated(obj::PolymakeCallable) = haskey(obj.json, "type_params")
+templates(obj::PolymakeCallable) = get(obj.json, "type_params", Dict[])
+mandatorytemplates(obj::PolymakeCallable) = get(obj.json, "mandatory_type_params", 0)
 
 function Base.show(io::IO, pc::PolymakeCallable)
     println(io, typeof(pc), ":")

--- a/test/interface_functions.jl
+++ b/test/interface_functions.jl
@@ -14,7 +14,7 @@
     @test @pm polytope.equal_polyhedra(c, cc)
     @test polytope.equal_polyhedra(c, cc)
 
-    @test tropical.cyclic(3,5,template_parameters=["Max"]) isa Polymake.BigObject
+    @test tropical.cyclic{max}(3,5) isa Polymake.BigObject
 
     @test (@pm tropical.cyclic{Max}(3,5)) isa Polymake.BigObject
 

--- a/test/interface_functions.jl
+++ b/test/interface_functions.jl
@@ -15,6 +15,7 @@
     @test polytope.equal_polyhedra(c, cc)
 
     @test tropical.cyclic{max}(3,5) isa Polymake.BigObject
+    @test_throws ArgumentError tropical.cyclic(3,5)
 
     @test (@pm tropical.cyclic{Max}(3,5)) isa Polymake.BigObject
 


### PR DESCRIPTION
Add function parameters as templates similar to bigobjects, depending on number of type parameters and mandatory count in json file.

`@pm` still exists as fallback for non-mapped types.