### PR TITLE
fix wrapper cleanup during build

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -100,22 +100,26 @@ If you already have a polymake installation you need to set the environment vari
     pm_config_ninja = joinpath(libdir(prefix),"polymake","config.ninja")
     pm_bin_prefix = joinpath(@__DIR__,"usr")
     perllib = replace(chomp(read(`$perl -e 'print join(":",@INC);'`,String)),"/workspace/destdir/"=>prefix.path)
-    global depsjl = quote
-        using Pkg: depots1
-        function prepare_env()
-            ENV["PERL5LIB"]=$perllib
-            user_dir = ENV["POLYMAKE_USER_DIR"] = abspath(joinpath(depots1(),"polymake_user"))
-            if Base.Filesystem.isdir(user_dir)
-                del = filter(i -> Base.Filesystem.isdir(i) && startswith(i, "wrappers."), readdir(user_dir))
-                for i in del
-                    Base.Filesystem.rm(user_dir * "/" * i, recursive = true)
-                end
+    depsjl = :(
+        ENV["PERL5LIB"]=$perllib;
+        ENV["POLYMAKE_USER_DIR"] = abspath(joinpath(Pkg.depots1(),"polymake_user"));
+        ENV["PATH"] = ENV["PATH"]*":"*joinpath($pm_bin_prefix,"bin");
+        )
+    eval(depsjl)
+
+    rex = Regex("\\s+'$(@__DIR__).*'\\s?=>\\s?'(?<wrappers_dir>wrappers\\.\\d+)'\\s?,?")
+    customize_file = joinpath(ENV["POLYMAKE_USER_DIR"], "customize.pl")
+    if isfile(customize_file)
+        for l in readlines()
+            m = match(rex, l)
+            if m !== nothing && m[:wrappers_dir] !== nothing
+                wrappers = joinpath(ENV["POLYMAKE_USER_DIR"], m[:wrappers_dir])
+                @info "Removing $(wrappers)"
+                # rm(wrappers, force=true, recursive=true)
             end
-            ENV["PATH"] = ENV["PATH"]*":"*$pm_bin_prefix*"/bin"
         end
     end
-    eval(depsjl)
-    prepare_env()
+
     run(`$perl -pi -e "s{REPLACEPREFIX}{$pm_bin_prefix}g" $pm_config $pm_config_ninja $polymake`)
 
     # adjust signal used for initalization purposes to avoid problems

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -101,21 +101,24 @@ If you already have a polymake installation you need to set the environment vari
     pm_bin_prefix = joinpath(@__DIR__,"usr")
     perllib = replace(chomp(read(`$perl -e 'print join(":",@INC);'`,String)),"/workspace/destdir/"=>prefix.path)
     depsjl = :(
-        ENV["PERL5LIB"]=$perllib;
-        ENV["POLYMAKE_USER_DIR"] = abspath(joinpath(Pkg.depots1(),"polymake_user"));
-        ENV["PATH"] = ENV["PATH"]*":"*joinpath($pm_bin_prefix,"bin");
+        function prepare_env()
+            ENV["PERL5LIB"]=$perllib;
+            ENV["POLYMAKE_USER_DIR"] = abspath(joinpath(Pkg.depots1(),"polymake_user"));
+            ENV["PATH"] = ENV["PATH"]*":"*joinpath($pm_bin_prefix,"bin");
+        end
         )
     eval(depsjl)
+    prepare_env()
 
     rex = Regex("\\s+'$(@__DIR__).*'\\s?=>\\s?'(?<wrappers_dir>wrappers\\.\\d+)'\\s?,?")
     customize_file = joinpath(ENV["POLYMAKE_USER_DIR"], "customize.pl")
     if isfile(customize_file)
-        for l in readlines()
+        for l in readlines(customize_file)
             m = match(rex, l)
             if m !== nothing && m[:wrappers_dir] !== nothing
                 wrappers = joinpath(ENV["POLYMAKE_USER_DIR"], m[:wrappers_dir])
                 @info "Removing $(wrappers)"
-                # rm(wrappers, force=true, recursive=true)
+                rm(wrappers, force=true, recursive=true)
             end
         end
     end

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -202,7 +202,7 @@ json_script = joinpath(@__DIR__,"rules","apptojson.pl")
 json_folder = joinpath(@__DIR__,"json")
 mkpath(json_folder)
 
-run(`$perl $polymake --iscript $json_script $json_folder`)
+run(`$perl $polymake --no-config --iscript $json_script $json_folder`)
 
 # remove old deps.jl first to avoid problems when switching from binary installation
 rm(joinpath(@__DIR__,"deps.jl"), force=true)

--- a/src/Polymake.jl
+++ b/src/Polymake.jl
@@ -18,6 +18,9 @@ import Base: ==, <, <=, *, -, +, //, ^, div, rem, one, zero,
     setdiff, setdiff!, setindex!, symdiff, symdiff!,
     union, union!
 
+# needed for deps.jl setting polymake_user
+import Pkg
+
 using SparseArrays
 import SparseArrays: AbstractSparseMatrix, findnz
 import SparseArrays


### PR DESCRIPTION
Also:
* use `--no-config` during json generation to ignore `polymake_user` dir and wrappers
* don't clean wrappers at startup

(Originally wrappers were supposed to be cleaned during build and during init but the code didn't actually remove them)