### PR TITLE
attachments for BigObject

### DIFF
--- a/deps/src/polymake_bigobjects.cpp
+++ b/deps/src/polymake_bigobjects.cpp
@@ -10,6 +10,8 @@
 
 #include "generated/option_set_take.h"
 
+#include "generated/polymake_call_function_feed_argument.h"
+
 void polymake_module_add_bigobject(jlcxx::Module& polymake)
 {
 
@@ -48,7 +50,19 @@ void polymake_module_add_bigobject(jlcxx::Module& polymake)
         .method("properties", [](pm::perl::BigObject p) {
             std::string x = p.call_method("properties");
             return x;
-        });
+        })
+        .method("_get_attachment", [](pm::perl::BigObject p, const std::string& s) {
+            return p.get_attachment(s);
+        })
+        .method("remove_attachment", [](pm::perl::BigObject p, const std::string& s) {
+            return p.remove_attachment(s);
+        })
+        .method("attach", [](pm::perl::BigObject p, const std::string& s,
+                              jl_value_t* v) {
+            auto pv_helper = p.attach(s);
+            polymake_call_function_feed_argument(pv_helper, v);
+        })
+        ;
 
     polymake.method("to_bool", [](pm::perl::PropertyValue p) {
         return static_cast<bool>(p);

--- a/src/perlobj.jl
+++ b/src/perlobj.jl
@@ -77,6 +77,14 @@ function convert_from_property_value(obj::PropertyValue)
     end
 end
 
+function get_attachment(obj::BigObject, name::String)
+   return convert_from_property_value(_get_attachment(obj,name))
+end
+
+function get_attachment(::Type{PropertyValue}, obj::BigObject, name::String)
+   return _get_attachment(obj,name)
+end
+
 function OptionSet(iter)
     opt_set = OptionSet()
     for (key, value) in iter

--- a/test/perlobj.jl
+++ b/test/perlobj.jl
@@ -120,6 +120,16 @@
         @test c.VERTICES[1,2] == -1//4
     end
 
+    @testset "attachments" begin
+        test_polytope = polytope.Polytope(POINTS=points_int)
+        att = Polymake.Matrix{Polymake.Rational}(3,3)
+        @test Polymake.attach(test_polytope,"ATT",att) === nothing
+        @test Polymake.get_attachment(test_polytope,"ATT") isa Polymake.Matrix
+        @test Polymake.get_attachment(Polymake.PropertyValue,test_polytope,"ATT") isa Polymake.PropertyValue
+        @test Polymake.remove_attachment(test_polytope,"ATT") === nothing
+        @test Polymake.get_attachment(test_polytope,"ATT") === nothing
+    end
+
     @testset "tab-completion" begin
         test_polytope = @pm polytope.Polytope(POINTS=points_int)
 


### PR DESCRIPTION
Adds `attach(obj,name,att)`, `get_attachment(obj,name)` and `remove_attachment(obj,name)` for adding, retrieving and removing attachments.

All interfaced types should work for storing as well as opaque `PropertyValue` objects. Similar to `give` they can be retrieved and converted automatically, or kept as `PropertyValue` by passing `PropertyValue` as first argument to `get_attachment`.
 `get_attachment` will return `nothing` when there is no such attachment.

Needed for the polyDB attachment in #261 .