### PR TITLE
Make codecov only informational

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,1 +1,12 @@
 comment: off
+coverage:
+  status:
+    project:
+      default:
+        threshold: 1%
+        informational: true
+        only_pulls: false
+    patch:
+      default:
+        threshold: 1%
+        informational: true


### PR DESCRIPTION
This changes the behaviour of the codecoverage check to always be green, but still giving us the information about the coverage.
Since we so far didn't care at all about the failing checks, this is probably fine :)