### PR TITLE
Types/map

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -29,7 +29,7 @@ FLINT_jll = "~2.6.2"
 JSON = "^0.20, ^0.21"
 Perl_jll = "=5.30.3"
 julia = "^1.3"
-libpolymake_julia_jll = "~0.1.0"
+libpolymake_julia_jll = "~0.1.1"
 polymake_jll = "~4.1.0"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -26,7 +26,7 @@ JSON = "^0.20, ^0.21"
 Mongoc = "~0.5.0, ~0.6.0"
 Perl_jll = "=5.30.3"
 julia = "^1.3"
-libpolymake_julia_jll = "~0.1.1"
+libpolymake_julia_jll = "~0.1.2"
 polymake_jll = "~4.1.0"
 
 [extras]

--- a/src/Polymake.jl
+++ b/src/Polymake.jl
@@ -161,6 +161,7 @@ include("arrays.jl")
 include("incidencematrix.jl")
 include("tropicalnumber.jl")
 include("polynomial.jl")
+include("map.jl")
 
 include("polymake_direct_calls.jl")
 

--- a/src/Polymake.jl
+++ b/src/Polymake.jl
@@ -37,7 +37,7 @@ using Perl_jll
 using Ninja_jll
 using libpolymake_julia_jll
 
-const jlpolymake_version_range = (v"0.1.1",  v"0.2")
+const jlpolymake_version_range = (v"0.1.2",  v"0.2")
 
 struct PolymakeError <: Exception
     msg
@@ -60,7 +60,7 @@ jlpolymake_version() = VersionNumber(unsafe_string(ccall((:jlpolymake_version,li
 function checkversion()
   jlpolymakeversion = jlpolymake_version()
   if !(jlpolymake_version_range[1] <= jlpolymakeversion < jlpolymake_version_range[2])
-    error("This version of Polymake.jl requires libpolymake-julia in the range $(libpolymake_version_range), but version $jlpolymakeversion was found")
+    error("This version of Polymake.jl requires libpolymake-julia in the range $(jlpolymake_version_range), but version $jlpolymakeversion was found")
   end
 end
 

--- a/src/Polymake.jl
+++ b/src/Polymake.jl
@@ -167,5 +167,7 @@ include("polymake_direct_calls.jl")
 
 include("generate_applications.jl")
 
+include("get_attachment.jl")
+
 include("polydb.jl")
 end # of module Polymake

--- a/src/Polymake.jl
+++ b/src/Polymake.jl
@@ -37,7 +37,7 @@ using Perl_jll
 using Ninja_jll
 using libpolymake_julia_jll
 
-const jlpolymake_version_range = (v"0.1.0",  v"0.2")
+const jlpolymake_version_range = (v"0.1.1",  v"0.2")
 
 struct PolymakeError <: Exception
     msg

--- a/src/get_attachment.jl
+++ b/src/get_attachment.jl
@@ -1,0 +1,4 @@
+function get_attachment_map(obj::BigObject, str::String)
+    att = Polymake.get_attachment(obj, str)
+    return @convert_to Map{String, String} att
+end

--- a/src/map.jl
+++ b/src/map.jl
@@ -1,0 +1,12 @@
+function Map{String,String}()
+    return Map{to_cxx_type(String),to_cxx_type(String)}()
+end
+
+function Base.getindex(M::Map{TV, TK}, key) where {TV, TK}
+    return convert(to_jl_type(TV), _getindex(M, convert(to_cxx_type(String), key)))
+end
+
+function Base.setindex!(M::Map{TV, TK}, val, key::AbstractString) where {TV, TK}
+    _setindex!(M, convert(TV, val), convert(TK, key))
+    return val
+end

--- a/src/map.jl
+++ b/src/map.jl
@@ -25,7 +25,7 @@ function Base.iterate(M::Map{S,T}) where {S,T}
     state = beginiterator(M)
     elt = get_element(state)
     increment(state)
-    return Pair{to_jl_type(S), to_jl_type(T)}(elt), state
+    return Pair{to_jl_type(S), to_jl_type(T)}(elt[1], elt[2]), state
 end
 
 
@@ -35,6 +35,6 @@ function Base.iterate(M::Map{S,T}, state) where {S,T}
     else
         elt = get_element(state)
         increment(state)
-        return Pair{to_jl_type(S), to_jl_type(T)}(elt), state
+        return Pair{to_jl_type(S), to_jl_type(T)}(elt[1], elt[2]), state
     end
 end

--- a/src/map.jl
+++ b/src/map.jl
@@ -10,3 +10,31 @@ function Base.setindex!(M::Map{TV, TK}, val, key::AbstractString) where {TV, TK}
     _setindex!(M, convert(TV, val), convert(TK, key))
     return val
 end
+
+# show method
+function Base.show(io::IO, M::Map)
+    print(io, join(collect(M), "\n"))
+end
+
+# Iterator
+
+Base.eltype(M::Map{S,T}) where {S,T} = Pair{to_jl_type(S), to_jl_type(T)}
+
+function Base.iterate(M::Map{S,T}) where {S,T}
+    isempty(M) &&  return nothing
+    state = beginiterator(M)
+    elt = get_element(state)
+    increment(state)
+    return Pair{to_jl_type(S), to_jl_type(T)}(elt), state
+end
+
+
+function Base.iterate(M::Map{S,T}, state) where {S,T}
+    if isdone(M, state)
+        return nothing
+    else
+        elt = get_element(state)
+        increment(state)
+        return Pair{to_jl_type(S), to_jl_type(T)}(elt), state
+    end
+end

--- a/src/setup_types.jl
+++ b/src/setup_types.jl
@@ -12,6 +12,7 @@ const SmallObject = Union{
     TropicalNumber,
     IncidenceMatrix,
     Polynomial,
+    Map,
 }
 const VecOrMat_eltypes = Union{Int64, Integer, Rational, Float64, CxxWrap.CxxLong}
 

--- a/src/std/pairs.jl
+++ b/src/std/pairs.jl
@@ -2,6 +2,7 @@ StdPair(a::T,b::T) where T = StdPair{T,T}(a,b)
 StdPair(p::Pair) = StdPair(first(p), last(p))
 
 Base.Pair(p::StdPair) = Pair(first(p), last(p))
+Base.Pair{S, T}(p::StdPair) where {S, T} = Pair{S, T}(first(p), last(p))
 Base.convert(::Type{<:Pair{T,S}}, p::StdPair) where {T,S} =
     Pair(T(first(p)), S(last(p)))
 

--- a/test/map.jl
+++ b/test/map.jl
@@ -1,5 +1,5 @@
 @testset "Polymake.Map" begin
-    @test Map{String,String} <: Dict{Polymake.to_cxx_type(String),Polymake.to_cxx_type(String)}
+    @test Polymake.Map{String,String} <: AbstractDict{String,String}
     @testset "Constructors" begin
         @test Polymake.Map{String,String}() isa Polymake.Map{Polymake.to_cxx_type(String),Polymake.to_cxx_type(String)}
     end
@@ -8,7 +8,7 @@
         M["one"] = "Eins"
         @test M["one"] isa String
         @test M["one"] == "Eins"
-        @test_throws KeyError M["two"] #might need implementation
+        @test_throws ErrorException M["two"]
         @testset "Iterator" begin
             M["zero"] = "Null"
             M["infinity"] = "Unendlich"

--- a/test/map.jl
+++ b/test/map.jl
@@ -1,0 +1,19 @@
+@testset "Polymake.Map" begin
+    @test Map{String,String} <: Dict{Polymake.to_cxx_type(String),Polymake.to_cxx_type(String)}
+    @testset "Constructors" begin
+        @test Polymake.Map{String,String}() isa Polymake.Map{Polymake.to_cxx_type(String),Polymake.to_cxx_type(String)}
+    end
+    @testset "Accessing the content" begin
+        M = Polymake.Map{String,String}()
+        M["one"] = "Eins"
+        @test M["one"] isa String
+        @test M["one"] == "Eins"
+        @test_throws KeyError M["two"] #might need implementation
+        @testset "Iterator" begin
+            M["zero"] = "Null"
+            M["infinity"] = "Unendlich"
+            @test eltype(M) == Pair{String,String}
+            @test sort(collect(M)) == sort(["one" => "Eins", "zero" => "Null", "infinity" => "Unendlich"])
+        end
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -26,6 +26,7 @@ struct MyInt x::Int end # needed in test/convert.jl
     include("polynomial.jl")
     include("pairs.jl")
     include("lists.jl")
+    include("map.jl")
     if get(ENV, "POLYDB_TEST_URI", "") != ""
         include("polydb.jl")
     end


### PR DESCRIPTION
this pull request allows us to access attachments with the new method `Polymake.get_attachment_map(::Polymake.BigObject, ::String)` using the newly wrapped type `Polymake.Map{String, String}`, for which the iterator is included. as this gives us `<std::pair<std::string,std::string>>` objects on the C++ side, this also required an extenstion of `Polymake.StdPair` for two `String` elements.

for the moment, i kept things simple by sticking to this specific use case. especially due to two type parameters, which could theoretically take any type, extending this type would mean a lot of text in context of the `type_setup.jl` table. so what useful features do we still need here?