### PR TITLE
workflow: add ssh key secret for tagbot to allow triggering of documenter

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -9,3 +9,4 @@ jobs:
       - uses: JuliaRegistries/TagBot@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          ssh: ${{ secrets.DOCUMENTER_KEY }}

--- a/.github/workflows/createdocumentation.yml
+++ b/.github/workflows/createdocumentation.yml
@@ -6,6 +6,7 @@ on:
       - master
     tags: '*'
   pull_request:
+  workflow_dispatch:
 
 jobs:
   create-documentation:

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Polymake"
 uuid = "d720cf60-89b5-51f5-aff5-213f193123e7"
 repo = "https://github.com/oscar-system/Polymake.jl.git"
-version = "0.5.0"
+version = "0.5.1"
 
 [deps]
 CxxWrap = "1f15a43c-97ca-5a2a-ae31-89f07a497df4"


### PR DESCRIPTION
see #317 for previous discussion

dev-docs work fine but no docs were built for 0.5 so I added an ssh key for tagbot to the github secrets (and deploy keys) and added it to the workflow file
