### PR TITLE
new jll wrappers have PATH as a RefValue instead ...

### DIFF
--- a/src/Polymake.jl
+++ b/src/Polymake.jl
@@ -96,8 +96,8 @@ function __init__()
     global user_dir = abspath(joinpath(Pkg.depots1(),"polymake_user"))
     
     # prepare environment variables
-    ENV["PATH"] *= ":" * Ninja_jll.PATH
-    ENV["PATH"] *= ":" * Perl_jll.PATH
+    ENV["PATH"] *= ":" * (isa(Ninja_jll.PATH,Ref) ? Ninja_jll.PATH[] : Ninja_jll.PATH)
+    ENV["PATH"] *= ":" * (isa(Perl_jll.PATH,Ref) ? Perl_jll.PATH[] : Perl_jll.PATH)
     ENV["POLYMAKE_USER_DIR"] = user_dir
     mkpath(user_dir)
 


### PR DESCRIPTION
the only "public api" would be a do block but that wont work as we need
the path to be set for all polymake code and not just one execution.