### PR TITLE
move perl and ninja paths to the beginning of PATH

### DIFF
--- a/src/Polymake.jl
+++ b/src/Polymake.jl
@@ -96,8 +96,7 @@ function __init__()
     global user_dir = abspath(joinpath(Pkg.depots1(),"polymake_user"))
     
     # prepare environment variables
-    ENV["PATH"] *= ":" * (isa(Ninja_jll.PATH,Ref) ? Ninja_jll.PATH[] : Ninja_jll.PATH)
-    ENV["PATH"] *= ":" * (isa(Perl_jll.PATH,Ref) ? Perl_jll.PATH[] : Perl_jll.PATH)
+    ENV["PATH"] = string(Ninja_jll.PATH[], ":", Perl_jll.PATH[], ":", ENV["PATH"])
     ENV["POLYMAKE_USER_DIR"] = user_dir
     mkpath(user_dir)
 


### PR DESCRIPTION
Needed to fix https://github.com/oscar-system/LoadFlint.jl/pull/13
(the jll style `perl() do ... end` code also adds all new paths to the beginning but we cannot use that syntax directly)

While I'm there, also remove old-style PATH access, which should not be necessary anymore.

