### PR TITLE
polymake_jll: adjust for deps_tree change from init_block to script

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Polymake"
 uuid = "d720cf60-89b5-51f5-aff5-213f193123e7"
 repo = "https://github.com/oscar-system/Polymake.jl.git"
-version = "0.5.2"
+version = "0.5.3"
 
 [deps]
 CxxWrap = "1f15a43c-97ca-5a2a-ae31-89f07a497df4"
@@ -26,8 +26,8 @@ JSON = "^0.20, ^0.21"
 Mongoc = "~0.5.0, ~0.6.0"
 Perl_jll = "=5.30.3"
 julia = "^1.3"
-libpolymake_julia_jll = "~0.2.0"
-polymake_jll = "~4.2.0"
+libpolymake_julia_jll = "~0.3.0"
+polymake_jll = "~4.2.1"
 
 [extras]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"

--- a/src/Polymake.jl
+++ b/src/Polymake.jl
@@ -18,7 +18,6 @@ import Base: ==, <, <=, *, -, +, //, ^, div, rem, one, zero,
     setdiff, setdiff!, setindex!, symdiff, symdiff!,
     union, union!
 
-# needed for setting polymake_user
 import Pkg
 
 using SparseArrays
@@ -35,9 +34,10 @@ using FLINT_jll
 
 using Perl_jll
 using Ninja_jll
+using polymake_jll
 using libpolymake_julia_jll
 
-const jlpolymake_version_range = (v"0.2.0",  v"0.3")
+const jlpolymake_version_range = (v"0.2.0",  v"0.4")
 
 struct PolymakeError <: Exception
     msg
@@ -84,6 +84,10 @@ end
 
 include(type_translator)
 
+include(polymake_jll.generate_deps_tree)
+
+const polymake_deps_tree = prepare_deps_tree()
+
 function __init__()
     if length(get(ENV,"POLYMAKE_CONFIG","")) > 0
          @warn "Setting `POLYMAKE_CONFIG` to use a custom polymake installation is no longer supported. Please use `Overrides.toml` to override `polymake_jll` and `libpolymake_julia_jll`."
@@ -99,6 +103,8 @@ function __init__()
     ENV["PATH"] = string(Ninja_jll.PATH[], ":", Perl_jll.PATH[], ":", ENV["PATH"])
     ENV["POLYMAKE_USER_DIR"] = user_dir
     mkpath(user_dir)
+
+    ENV["POLYMAKE_DEPS_TREE"] = polymake_deps_tree
 
     try
         show_banner = isinteractive() &&

--- a/src/polydb.jl
+++ b/src/polydb.jl
@@ -64,7 +64,7 @@ Polymake.Polydb.Database
 """
 function get_db()
    # we explicitly set the cacert file, otherwise we might get connection errors because the certificate cannot be validated
-   client = Mongoc.Client(get(ENV, "POLYDB_TEST_URI", "mongodb://polymake:database@db.polymake.org/?authSource=admin&ssl=true&sslCertificateAuthorityFile=$(cacert)"))
+   client = Mongoc.Client(get(ENV, "POLYDB_TEST_URI", "mongodb://polymake:database@db.polymake.org/?authSource=admin&ssl=true&sslCertificateAuthorityFile=$(MozillaCACerts_jll.cacert)"))
    return Database(client["polydb"])
 end
 


### PR DESCRIPTION
bump versions for dependencies to make sure the new versions are used
and old Polymake.jl versions can keep using the old ones

note that jlpolymake_version_range still allows 0.2 as I forgot to bump
that version in libpolymake_julia 0.3 but that should not matter as the
version is fixed via project.toml as well (and there are no real changes
in the c++ code)