### PR TITLE
bump to 0.5.4, update jll versions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Polymake"
 uuid = "d720cf60-89b5-51f5-aff5-213f193123e7"
 repo = "https://github.com/oscar-system/Polymake.jl.git"
-version = "0.5.3"
+version = "0.5.4"
 
 [deps]
 CxxWrap = "1f15a43c-97ca-5a2a-ae31-89f07a497df4"
@@ -21,13 +21,13 @@ polymake_jll = "7c209550-9012-526c-9264-55ba7a78ba2c"
 
 [compat]
 CxxWrap = "0.10.1, 0.11"
-FLINT_jll = "~2.6.2"
+FLINT_jll = "~200.700.0"
 JSON = "^0.20, ^0.21"
 Mongoc = "~0.5.0, ~0.6.0"
 Perl_jll = "=5.30.3"
 julia = "^1.3"
-libpolymake_julia_jll = "~0.3.0"
-polymake_jll = "~4.2.1"
+libpolymake_julia_jll = "~0.4.0"
+polymake_jll = "~400.300.0"
 
 [extras]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"

--- a/src/Polymake.jl
+++ b/src/Polymake.jl
@@ -37,7 +37,7 @@ using Ninja_jll
 using polymake_jll
 using libpolymake_julia_jll
 
-const jlpolymake_version_range = (v"0.2.0",  v"0.4")
+const jlpolymake_version_range = (v"0.4.0",  v"0.5")
 
 struct PolymakeError <: Exception
     msg


### PR DESCRIPTION
For FLINT 2.7, polymake 4.3 and using the new *100 version scheme for the jlls.

At the moment the required `libpolymake_julia` binaries only exist for julia 1.3, more will follow.