### PR TITLE
Fix html for summary in Firefox

### DIFF
--- a/src/visual.jl
+++ b/src/visual.jl
@@ -49,7 +49,12 @@ function Base.show(io::IO, ::MIME"text/html", obj::BigObject)
             key, val = a, ""
         end
 
-        props[i] = "<details><summary>$key</summary><pre>$val</pre></details>"
+        props[i] = """
+            <details>
+                <summary style='display:list-item;'>$key</summary>
+                <pre>$val</pre>
+            </details>
+         """
     end
 
     preamble = ("<dt>$t</dt><dd>$d</dd>" for (t,d) in split.(summary, ":"; limit=2))


### PR DESCRIPTION
This is only for the Jupyter notebook property description of big 
objects.
Without this fix the little triangle allowing to show/hide property 
values is missing in Firefox since default CSS values are overwritten by 
some CSS loaded in Jupyter (`normalize.css` to be precise).

Before:

<img width="626" alt="Screen Shot 2021-01-27 at 11 01 57" src="https://user-images.githubusercontent.com/4854317/106101509-4812f280-613e-11eb-845e-4e8745be24c8.png">

Now:

<img width="625" alt="Screen Shot 2021-01-27 at 11 02 02" src="https://user-images.githubusercontent.com/4854317/106101518-4c3f1000-613e-11eb-89d7-026a80de539d.png">
