### PR TITLE
CI: test on macos11 / update julia versions

### DIFF
--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -65,16 +65,10 @@ jobs:
           - '1.5'
           - '~1.6.0-0'
           - 'nightly'
-        os: ['ubuntu-latest', 'macOS-latest', 'macos-11.0']
+        os: ['ubuntu-latest', 'macOS-latest']
         # empty entry for defaults
         xcode: [ '' ]
         cxxwrap: [ '' ]
-        exclude:
-        # remove some macOS tests to keep the total number small
-          - os: macos-11.0
-            julia-version: '1.4'
-          - os: macos-11.0
-            julia-version: '1.5'
         # add a few extra tests: xcode 11.4, julia 1.3 with cxxwrap 0.11.0, legacy cxxwrap, several ubuntu lts versions
         include:
           - xcode: '11.4'
@@ -89,6 +83,8 @@ jobs:
           - cxxwrap: '0.10'
             os: ubuntu-latest
             julia-version: 1.5
+          - os: macos-11.0
+            julia-version: '~1.6.0-0'
           - os: ubuntu-20.04
             julia-version: 1.5
           - os: ubuntu-18.04

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -71,14 +71,18 @@ jobs:
         include:
           - xcode: '11.4'
             os: macos-latest
-            julia-version: 1.4
+            julia-version: 1.5
+          - os: macos-11.0
+            julia-version: 1.5
           - cxxwrap: '0.10'
             os: ubuntu-latest
-            julia-version: 1.4
+            julia-version: 1.5
           - os: ubuntu-20.04
-            julia-version: 1.4
+            julia-version: 1.5
+          - os: ubuntu-18.04
+            julia-version: 1.5
           - os: ubuntu-16.04
-            julia-version: 1.4
+            julia-version: 1.5
 
       fail-fast: false
 

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -17,7 +17,6 @@ jobs:
     strategy:
       matrix:
         julia-version:
-          - '1.3'
           - '1.4'
           - '1.5'
           - '~1.6.0-0'
@@ -62,7 +61,6 @@ jobs:
     strategy:
       matrix:
         julia-version:
-          - '1.3'
           - '1.4'
           - '1.5'
           - '~1.6.0-0'
@@ -73,15 +71,21 @@ jobs:
         cxxwrap: [ '' ]
         exclude:
         # remove some macOS tests to keep the total number small
-          - os: macos-latest
-            julia-version: '1.3'
-          - os: macos-latest
-            julia-version: 'nightly'
-        # add a few extra tests: xcode 11.4, legacy cxxwrap, and several ubuntu lts versions
+          - os: macos-11.0
+            julia-version: '1.4'
+          - os: macos-11.0
+            julia-version: '1.5'
+        # add a few extra tests: xcode 11.4, julia 1.3 with cxxwrap 0.11.0, legacy cxxwrap, several ubuntu lts versions
         include:
           - xcode: '11.4'
             os: macos-latest
             julia-version: 1.5
+          - cxxwrap: '0.11.0'
+            os: ubuntu-latest
+            julia-version: 1.3
+          - cxxwrap: '0.11.0'
+            os: macos-latest
+            julia-version: 1.3
           - cxxwrap: '0.10'
             os: ubuntu-latest
             julia-version: 1.5

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -16,8 +16,13 @@ jobs:
     continue-on-error: ${{ matrix.julia-version == 'nightly' }}
     strategy:
       matrix:
-        julia-version: ['1.3', '1.4', '1.5', 'nightly']
-        os: [ubuntu-latest]
+        julia-version:
+          - '1.3'
+          - '1.4'
+          - '1.5'
+          - '~1.6.0-0'
+          - 'nightly'
+        os: ['ubuntu-latest']
       fail-fast: false
     # Service containers to run
     services:
@@ -56,8 +61,13 @@ jobs:
     continue-on-error: ${{ matrix.julia-version == 'nightly' }}
     strategy:
       matrix:
-        julia-version: ['1.3', '1.4', '1.5', 'nightly']
-        os: [ubuntu-latest, macOS-latest]
+        julia-version:
+          - '1.3'
+          - '1.4'
+          - '1.5'
+          - '~1.6.0-0'
+          - 'nightly'
+        os: ['ubuntu-latest', 'macOS-latest', 'macos-11.0']
         # empty entry for defaults
         xcode: [ '' ]
         cxxwrap: [ '' ]
@@ -67,12 +77,10 @@ jobs:
             julia-version: '1.3'
           - os: macos-latest
             julia-version: 'nightly'
-        # add a few extra tests: xcode 11.4 bug and legacy cxxwrap
+        # add a few extra tests: xcode 11.4, legacy cxxwrap, and several ubuntu lts versions
         include:
           - xcode: '11.4'
             os: macos-latest
-            julia-version: 1.5
-          - os: macos-11.0
             julia-version: 1.5
           - cxxwrap: '0.10'
             os: ubuntu-latest


### PR DESCRIPTION
Let's see if macos 11 is stable enough yet.

Update versions especially to add 1.6, drop a few 1.3 tests, and fix cxxwrap version on the remaining 1.3 tests.