### PR TITLE
bump dependencies for polymake 4.4

### DIFF
--- a/.github/workflows/oscar.yml
+++ b/.github/workflows/oscar.yml
@@ -12,6 +12,7 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     env:
       PR_NUMBER: ${{github.event.number}}
+      JULIA_PKG_SERVER: ""
     steps:
     - uses: actions/checkout@v2.1.0
     - name: "Set up Julia"
@@ -47,6 +48,7 @@ jobs:
     continue-on-error: ${{ matrix.julia-version == 'nightly' }}
     env:
       PR_NUMBER: ${{github.event.number}}
+      JULIA_PKG_SERVER: ""
     strategy:
       matrix: ${{fromJSON(needs.generatematrix.outputs.matrix)}}
       fail-fast: false

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -37,7 +37,8 @@ jobs:
           # Maps tcp port 27017 on service container to the host
           - 27017:27017
     env:
-        POLYDB_TEST_URI: "mongodb://admin:admin@localhost:27017/?authSource=admin"
+      JULIA_PKG_SERVER: ""
+      POLYDB_TEST_URI: "mongodb://admin:admin@localhost:27017/?authSource=admin"
     steps:
       - uses: actions/checkout@v2.1.0
       - name: "Set up Julia"
@@ -58,6 +59,8 @@ jobs:
   test:
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.julia-version == 'nightly' }}
+    env:
+      JULIA_PKG_SERVER: ""
     strategy:
       matrix:
         julia-version:

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Polymake"
 uuid = "d720cf60-89b5-51f5-aff5-213f193123e7"
 repo = "https://github.com/oscar-system/Polymake.jl.git"
-version = "0.5.5"
+version = "0.5.6"
 
 [deps]
 CxxWrap = "1f15a43c-97ca-5a2a-ae31-89f07a497df4"
@@ -26,8 +26,7 @@ JSON = "^0.20, ^0.21"
 Mongoc = "~0.5.0, ~0.6.0"
 Perl_jll = "=5.30.3"
 julia = "^1.3"
-libpolymake_julia_jll = "~0.4.0"
-polymake_jll = "~400.300.0"
+libpolymake_julia_jll = "~0.4.110"
 
 [extras]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"


### PR DESCRIPTION
the polymake_jll version is now fixed via the libpolymake_julia compat entry
prepare for version 0.5.6

draft until the last libpolymake_julia_jll is registered (i.e. tests for julia 1.6 will probably fail until that is complete)