### PR TITLE
prepare for new release using flint 2.8

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -24,7 +24,7 @@ CxxWrap = "0.10.1, 0.11"
 JSON = "^0.20, ^0.21"
 Mongoc = "~0.5.0, ~0.6.0"
 julia = "^1.3"
-libpolymake_julia_jll = "~0.4.110"
+libpolymake_julia_jll = "~0.4.120"
 
 [extras]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"

--- a/Project.toml
+++ b/Project.toml
@@ -21,10 +21,8 @@ polymake_jll = "7c209550-9012-526c-9264-55ba7a78ba2c"
 
 [compat]
 CxxWrap = "0.10.1, 0.11"
-FLINT_jll = "~200.700.0"
 JSON = "^0.20, ^0.21"
 Mongoc = "~0.5.0, ~0.6.0"
-Perl_jll = "=5.30.3"
 julia = "^1.3"
 libpolymake_julia_jll = "~0.4.110"
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Polymake"
 uuid = "d720cf60-89b5-51f5-aff5-213f193123e7"
 repo = "https://github.com/oscar-system/Polymake.jl.git"
-version = "0.5.6"
+version = "0.5.7"
 
 [deps]
 CxxWrap = "1f15a43c-97ca-5a2a-ae31-89f07a497df4"


### PR DESCRIPTION
They are fixed via `polymake_jll` for a while now and no need to keep updating them here as well. Bump version to prepare for new release supporting FLINT 2.8.