### PR TITLE
Combine incidencematrix

### DIFF
--- a/src/broadcast.jl
+++ b/src/broadcast.jl
@@ -45,12 +45,12 @@ for dim in (1, 2)
     end
 end
 
-function Base.similar(X::IncidenceMatrix,
+function Base.similar(X::Union{IncidenceMatrix, SparseVector},
     ::Type{<:Union{Bool, CxxWrap.CxxBool}}, dims::Dims{1})
     return spzeros(Bool, dims...)
 end
 
-function Base.similar(X::IncidenceMatrix,
+function Base.similar(X::Union{IncidenceMatrix, SparseVector},
     ::Type{<:Union{Bool, CxxWrap.CxxBool}}, dims::Dims{2})
     return IncidenceMatrix{NonSymmetric}(undef, dims...)
 end

--- a/src/broadcast.jl
+++ b/src/broadcast.jl
@@ -47,7 +47,7 @@ end
 
 function Base.similar(X::IncidenceMatrix,
     ::Type{<:Union{Bool, CxxWrap.CxxBool}}, dims::Dims{1})
-    return BitArray{1}(undef, dims...)
+    return spzeros(Bool, dims...)
 end
 
 function Base.similar(X::IncidenceMatrix,

--- a/src/broadcast.jl
+++ b/src/broadcast.jl
@@ -45,12 +45,22 @@ for dim in (1, 2)
     end
 end
 
-function Base.similar(X::Union{IncidenceMatrix, SparseVector},
+function Base.similar(X::SparseVector,
     ::Type{<:Union{Bool, CxxWrap.CxxBool}}, dims::Dims{1})
     return spzeros(Bool, dims...)
 end
 
-function Base.similar(X::Union{IncidenceMatrix, SparseVector},
+function Base.similar(X::SparseVector,
+    ::Type{<:Union{Bool, CxxWrap.CxxBool}}, dims::Dims{2})
+    return IncidenceMatrix{NonSymmetric}(undef, dims...)
+end
+
+function Base.similar(X::IncidenceMatrix,
+    ::Type{<:Union{Bool, CxxWrap.CxxBool}}, dims::Dims{1})
+    return spzeros(Bool, dims...)
+end
+
+function Base.similar(X::IncidenceMatrix,
     ::Type{<:Union{Bool, CxxWrap.CxxBool}}, dims::Dims{2})
     return IncidenceMatrix{NonSymmetric}(undef, dims...)
 end

--- a/src/incidencematrix.jl
+++ b/src/incidencematrix.jl
@@ -93,7 +93,7 @@ Base.@propagate_inbounds function col(M::IncidenceMatrix, j::Base.Integer)
 end
 
 function _findnz(M::IncidenceMatrix)
-    len = sum(([length(row(M, i)) for i in 1:size(M, 1)]))
+    len = sum(length, (row(M, i) for i in 1:size(M, 1)))
     ri = Base.Vector{Int64}(undef, len)
     ci = Base.Vector{Int64}(undef, len)
     k = 1
@@ -124,34 +124,40 @@ function Base.resize!(M::IncidenceMatrix{Symmetric}, n::Base.Integer)
     _resize!(M,Int64(n),Int64(n))
 end
 
-function Base.show(io::IO, ::MIME"text/plain", M::IncidenceMatrix)
+function Base.show(io::IO, ::MIME{Symbol("text/plain")}, M::IncidenceMatrix)
     m,n = size(M)
+    a,b = displaysize(io)
+    s = min(a - 5, size(M, 1))
     print(io, "$m×$n IncidenceMatrix\n")
-    for i in 1:min(20, size(M, 1))
-        print(io, "($i) - ")
-        join(io, [i for i in M[i,:].s][1:min(20,length(M[i,:].s))], ", ")
-        if (length(M[i,:]) > 20)
+    for i in 1:s
+        t = min(div(b, 2 + ndigits(size(M, 2))) - 1, length(row(M, i)))
+        print(io, "[")
+        join(io, [c for c in row(M, i)][1:t], ", ")
+        if (length(row(M,i)) > t)
             print(io, ", …")
         end
-        print(io, "\n")
+        print(io, "]\n")
     end
-    if (size(M, 1) > 20)
+    if (m > s)
         print(io, "⁝")
     end
 end
 
 function Base.show(io::IOContext, ::MIME{Symbol("text/plain")}, M::IncidenceMatrix)
     m,n = size(M)
+    a,b = displaysize(io)
+    s = min(a - 5, size(M, 1))
     print(io, "$m×$n IncidenceMatrix\n")
-    for i in 1:min(20, size(M, 1))
-        print(io, "($i) - ")
-        join(io, [i for i in M[i,:].s][1:min(20,length(M[i,:].s))], ", ")
-        if (length(M[i,:]) > 20)
+    for i in 1:s
+        t = min(div(b, 2 + ndigits(size(M, 2))) - 1, length(row(M, i)))
+        print(io, "[")
+        join(io, [c for c in row(M, i)][1:t], ", ")
+        if (length(row(M,i)) > t)
             print(io, ", …")
         end
-        print(io, "\n")
+        print(io, "]\n")
     end
-    if (size(M, 1) > 20)
+    if (m > s)
         print(io, "⁝")
     end
 end

--- a/src/incidencematrix.jl
+++ b/src/incidencematrix.jl
@@ -50,9 +50,9 @@ function IncidenceMatrix{Symmetric}(mat::AbstractSparseMatrix)
     return res
 end
 
-function IncidenceMatrix{NonSymmetric}(TrueIndices::Base.Array{Base.Array{Int64,1},1}) where T
+function IncidenceMatrix{NonSymmetric}(TrueIndices::AbstractVector{<:AbstractVector{<:Base.Integer}}) where T
     m = length(TrueIndices)
-    n = maximum([maximum(set) for set in TrueIndices])
+    n = maximum(maximum, TrueIndices)
     res = IncidenceMatrix(m, n)
     i = 1
     for set in TrueIndices

--- a/src/incidencematrix.jl
+++ b/src/incidencematrix.jl
@@ -50,18 +50,18 @@ function IncidenceMatrix{Symmetric}(mat::AbstractSparseMatrix)
     return res
 end
 
-function IncidenceMatrix{NonSymmetric}(TrueIndices::AbstractVector{<:AbstractVector{<:Base.Integer}}) where T
-    m = length(TrueIndices)
-    n = maximum(maximum, TrueIndices)
+function IncidenceMatrix{NonSymmetric}(incidenceRows::AbstractVector{<:AbstractVector{<:Base.Integer}}) where T
+    m = length(incidenceRows)
+    n = maximum(maximum, incidenceRows)
     res = IncidenceMatrix(m, n)
     i = 1
-    for set in TrueIndices
+    for set in incidenceRows
         for j in set
             res[i,j] = 1
         end
         i = i+1
     end
-   return res
+    return res
 end
 
 # set default parameter to NonSymmetric
@@ -124,24 +124,8 @@ function Base.resize!(M::IncidenceMatrix{Symmetric}, n::Base.Integer)
     _resize!(M,Int64(n),Int64(n))
 end
 
-function Base.show(io::IO, ::MIME{Symbol("text/plain")}, M::IncidenceMatrix)
-    m,n = size(M)
-    a,b = displaysize(io)
-    s = min(a - 5, size(M, 1))
-    print(io, "$m×$n IncidenceMatrix\n")
-    for i in 1:s
-        t = min(div(b, 2 + ndigits(size(M, 2))) - 1, length(row(M, i)))
-        print(io, "[")
-        join(io, [c for c in row(M, i)][1:t], ", ")
-        if (length(row(M,i)) > t)
-            print(io, ", …")
-        end
-        print(io, "]\n")
-    end
-    if (m > s)
-        print(io, "⁝")
-    end
-end
+Base.show(io::IO, tp::MIME{Symbol("text/plain")}, M::IncidenceMatrix) =
+    Base.show(IOContext(io), tp, M)
 
 function Base.show(io::IOContext, ::MIME{Symbol("text/plain")}, M::IncidenceMatrix)
     m,n = size(M)

--- a/src/incidencematrix.jl
+++ b/src/incidencematrix.jl
@@ -50,6 +50,20 @@ function IncidenceMatrix{Symmetric}(mat::AbstractSparseMatrix)
     return res
 end
 
+function IncidenceMatrix{NonSymmetric}(TrueIndices::Base.Array{Base.Array{Int64,1},1}) where T
+    m = length(TrueIndices)
+    n = maximum([maximum(set) for set in TrueIndices])
+    res = IncidenceMatrix(m, n)
+    i = 1
+    for set in TrueIndices
+        for j in set
+            res[i,j] = 1
+        end
+        i = i+1
+    end
+   return res
+end
+
 # set default parameter to NonSymmetric
 IncidenceMatrix(x...) = IncidenceMatrix{NonSymmetric}(x...)
 
@@ -87,4 +101,20 @@ end
 function Base.resize!(M::IncidenceMatrix{Symmetric}, n::Base.Integer)
     n >= 0 || throw(DomainError(n, "can not resize to a negative length"))
     _resize!(M,Int64(n),Int64(n))
+end
+
+function Base.show(io::IO, ::MIME"text/plain", M::IncidenceMatrix)
+    m,n = size(M)
+    print(io, "$m×$n IncidenceMatrix\n")
+    for i in 1:min(20, size(M, 1))
+        print(io, "($i) - ")
+        join(io, [i for i in M[i,:].s][1:min(20,length(M[i,:].s))], ", ")
+        if (length(M[i,:]) > 20)
+            print(io, ", …")
+        end
+        print(io, "\n")
+    end
+    if (size(M, 1) > 20)
+        print(io, "⁝")
+    end
 end

--- a/src/sparsevector.jl
+++ b/src/sparsevector.jl
@@ -59,6 +59,8 @@ spzeros(::Type{Bool}, n::Base.Integer) = SparseVectorBool(n, Polymake.Set{Int64}
 Base.size(v::SparseVector{Bool}) = (v.l,)
 Base.eltype(::SparseVector{Bool}) = Bool
 
+Base.show(io::IOContext, ::MIME{Symbol("text/plain")}, v::Polymake.SparseVectorBool) = print(io, length(v), "-element SparseVectorBool. `true` for indices:\n", v.s...)
+
 Base.@propagate_inbounds function Base.getindex(V::SparseVector{Bool}, n::Base.Integer)
     (V.l >= n && n >= 1) || throw(BoundsError(V, n))
     return in(V, n)

--- a/src/sparsevector.jl
+++ b/src/sparsevector.jl
@@ -99,16 +99,8 @@ function SparseArrays.findnz(V::SparseVectorBool)
     return (i, trues(len))
 end
 
-function Base.show(io::IO, ::MIME"text/plain", V::SparseVectorBool)
-    t = min(div(displaysize(io)[2], 2 + ndigits(V.l)) - 1, length(V.s))
-    l = V.l
-    print(io, "$l-element SparseVectorBool\n[")
-    join(io, [i for i in V.s][1:t], ", ")
-    if (length(V.s) > t)
-        print(io, ", …")
-    end
-    print(io, "]")
-end
+Base.show(io::IO, tp::MIME"text/plain", V::SparseVectorBool) =
+    Base.show(IOContext(io), tp, V)
 
 function Base.show(io::IOContext, ::MIME"text/plain", V::SparseVectorBool)
     t = min(div(displaysize(io)[2], 2 + ndigits(V.l)) - 1, length(V.s))

--- a/src/sparsevector.jl
+++ b/src/sparsevector.jl
@@ -62,12 +62,12 @@ Base.eltype(::SparseVector{Bool}) = Bool
 Base.show(io::IOContext, ::MIME{Symbol("text/plain")}, v::Polymake.SparseVectorBool) = print(io, length(v), "-element SparseVectorBool. `true` for indices:\n", v.s...)
 
 Base.@propagate_inbounds function Base.getindex(V::SparseVector{Bool}, n::Base.Integer)
-    (V.l >= n && n >= 1) || throw(BoundsError(V, n))
+    @boundscheck checkbounds(V, n)
     return in(V, n)
 end
 
-Base.@propagate_inbounds function Base.setindex!(V::SparseVector{Bool}, val, n::Base.Integer)
-    (V.l >= n && n >= 1) || throw(BoundsError(V, n))
+Base.@propagate_inbounds function Base.setindex!(V::SparseVector{Bool}, val::Bool, n::Base.Integer)
+    @boundscheck checkbounds(V, n)
     if val
         push!(V.s, n)
     else

--- a/src/sparsevector.jl
+++ b/src/sparsevector.jl
@@ -54,7 +54,7 @@ struct SparseVectorBool <: SparseVector{Bool}
     s::Set{Int64}
 end
 
-spzeros(::Type{Bool}, n::Base.Integer) = SparseVectorBool(n, Polymake.Set{Int64}())
+spzeros(::Type{Bool}, n::Base.Integer) = SparseVectorBool(n, Polymake.Set{to_cxx_type(Int64)}())
 
 Base.size(v::SparseVector{Bool}) = (v.l,)
 Base.eltype(::SparseVector{Bool}) = Bool

--- a/src/sparsevector.jl
+++ b/src/sparsevector.jl
@@ -51,7 +51,7 @@ end
 # implementation of SparseVector{Bool} as Set{Integer} with Integer length
 struct SparseVectorBool <: SparseVector{Bool}
     l::Int64
-    s::Set{Int64}
+    s::Set{to_cxx_type(Int64)}
 end
 
 spzeros(::Type{Bool}, n::Base.Integer) = SparseVectorBool(n, Polymake.Set{to_cxx_type(Int64)}())

--- a/src/sparsevector.jl
+++ b/src/sparsevector.jl
@@ -78,7 +78,7 @@ end
 
 function Base.show(io::IO, ::MIME"text/plain", V::SparseVectorBool)
     l = V.l
-    print(io, "Incidence vector with $l entries. `true` for:\n")
+    print(io, "$l-element SparseVectorBool\n")
     join(io, [i for i in V.s][1:min(20, length(V.s))], ", ")
     if (length(V.s) > 20)
         print(io, ", …")

--- a/src/sparsevector.jl
+++ b/src/sparsevector.jl
@@ -48,7 +48,7 @@ function findnz(vec::SparseVector{T}) where T
     return (I, V)
 end
 
-# implementation of SparseVector{Bool} as Set{Integer} with Integer length
+# implementation of SparseVector{Bool} with Int64 length using a polymake Set
 struct SparseVectorBool <: SparseVector{Bool}
     l::Int64
     s::Set{to_cxx_type(Int64)}

--- a/test/incidencematrix.jl
+++ b/test/incidencematrix.jl
@@ -89,7 +89,7 @@ using SparseArrays
                 @test N[2, 2] = T(10) isa T
                 N[2, 2] = T(10)
                 @test N[2, 2] == true
-                @test string(N) == "2×3 IncidenceMatrix\n(1) - 1, 3\n(2) - 1, 2\n"
+                @test string(N) == "2×3 IncidenceMatrix\n[1, 3]\n[1, 2]\n"
                 # testing the return value when asking for a single row or column
                 @test Polymake.row(N, T(1)) isa Polymake.Set{Polymake.to_cxx_type(Int)}
                 @test Polymake.row(N, T(1)) == Set([1, 3])
@@ -126,7 +126,7 @@ using SparseArrays
                 S[1, 3] = T(0)
                 @test S[1, 3] == false
                 @test S[3, 1] == false
-                @test string(S) == "3×3 IncidenceMatrix\n(1) - 1\n(2) - \n(3) - 3\n"
+                @test string(S) == "3×3 IncidenceMatrix\n[1]\n[]\n[3]\n"
                 # testing the return value when asking for a single row or column
                 @test Polymake.row(S, T(2)) isa Polymake.Set{Polymake.to_cxx_type(Int)}
                 @test Polymake.row(S, T(2)) == Set([])

--- a/test/incidencematrix.jl
+++ b/test/incidencematrix.jl
@@ -89,7 +89,7 @@ using SparseArrays
                 @test N[2, 2] = T(10) isa T
                 N[2, 2] = T(10)
                 @test N[2, 2] == true
-                @test string(N) == "pm::IncidenceMatrix<pm::NonSymmetric>\n{0 2}\n{0 1}\n"
+                @test string(N) == "2×3 IncidenceMatrix\n(1) - 1, 3\n(2) - 1, 2\n"
                 # testing the return value when asking for a single row or column
                 @test Polymake.row(N, T(1)) isa Polymake.Set{Polymake.to_cxx_type(Int)}
                 @test Polymake.row(N, T(1)) == Set([1, 3])
@@ -126,7 +126,7 @@ using SparseArrays
                 S[1, 3] = T(0)
                 @test S[1, 3] == false
                 @test S[3, 1] == false
-                @test string(S) == "pm::IncidenceMatrix<pm::Symmetric>\n{0}\n{}\n{2}\n"
+                @test string(S) == "3×3 IncidenceMatrix\n(1) - 1\n(2) - \n(3) - 3\n"
                 # testing the return value when asking for a single row or column
                 @test Polymake.row(S, T(2)) isa Polymake.Set{Polymake.to_cxx_type(Int)}
                 @test Polymake.row(S, T(2)) == Set([])
@@ -146,7 +146,7 @@ using SparseArrays
             V = Polymake.IncidenceMatrix{S}(jl_s)
             @test (!).(V) isa Polymake.IncidenceMatrixAllocated{Polymake.NonSymmetric}
             @test float.(V) isa Polymake.MatrixAllocated{Float64}
-            @test V[1, :] isa BitArray{1}
+            @test V[1, :] isa Polymake.SparseVectorBool
             @test float.(V)[1, :] isa Polymake.Vector{Float64}
 
             @test similar(V, Bool) isa Polymake.IncidenceMatrixAllocated{Polymake.NonSymmetric}

--- a/test/incidencematrix.jl
+++ b/test/incidencematrix.jl
@@ -31,6 +31,13 @@ using SparseArrays
     jl_s = [1 0 1; 0 0 0; 1 0 0]
     jl_n = [0 0 1; 1 0 0]
     @testset "Constructors/Converts" begin
+        inc = [[1,2,4],[3,5]]
+        @test Polymake.IncidenceMatrix{Polymake.NonSymmetric}(inc) isa Polymake.IncidenceMatrix{Polymake.NonSymmetric}
+        M = Polymake.IncidenceMatrix{Polymake.NonSymmetric}(inc)
+        @test M[1,1] == true
+        @test M[2,1] == false
+        @test M[1,1] isa Bool
+        @test size(M) == (2,5)
         for N in [IntTypes; FloatTypes; Polymake.Integer; Polymake.Rational]
             @test Polymake.IncidenceMatrix(N.(jl_n)) isa Polymake.IncidenceMatrix{Polymake.NonSymmetric}
             @test Polymake.IncidenceMatrix{Polymake.NonSymmetric}(N.(jl_s)) isa Polymake.IncidenceMatrix{Polymake.NonSymmetric}
@@ -79,6 +86,14 @@ using SparseArrays
             resize!(N,2,3)
             @test size(N) == (2,3)
             @test N == jl_n
+
+            ri, ci, v = findnz(N)
+            @test ri == [1, 2]
+            @test ci == [3, 1]
+            @test v == [true, true]
+            nzi, v = findnz(N[1, :])
+            @test nzi == [3]
+            @test v == [true]
 
             for T in [IntTypes; Polymake.Integer]
                 N = Polymake.IncidenceMatrix(jl_n) # local copy

--- a/test/sparsevector.jl
+++ b/test/sparsevector.jl
@@ -156,8 +156,9 @@ using SparseArrays
         # @test float.(V)[1, :] isa SparseVector{Float64}
 
         @test similar(V, Float64) isa Polymake.SparseVectorAllocated{Float64}
-        # @test similar(V, Float64, 10) isa Polymake.SparseVectorAllocated{Float64}
         @test similar(V, Float64, 10) isa Polymake.SparseVectorAllocated{Float64}
+        @test similar(V, Bool, 10) isa Polymake.SparseVectorBool
+        @test similar(V, Bool, 2, 2) isa Polymake.IncidenceMatrixAllocated{Polymake.NonSymmetric}
 
         X = Polymake.SparseVector{Int64}(jl_v)
         V = Polymake.SparseVector{Polymake.Integer}(jl_v)


### PR DESCRIPTION
move functionality of `IncidenceMatrix` from Oscar to polymake and access functionality from there. functionality that is logically applicable to an `IncidenceMatrix` should usually be defined on the `Polymake.jl` side.

within Oscar, importing `IncidenceMatrix` from polymake and then exporting it removes the necessity to re-invent the wheel and re-define the required functionality again in Oscar.