### PR TITLE
lp2poly: pre-load LPparser during init

### DIFF
--- a/src/Polymake.jl
+++ b/src/Polymake.jl
@@ -121,6 +121,8 @@ function __init__()
 
     application("common")
     shell_execute("include(\"$(joinpath(@__DIR__, "polymake", "julia.rules"))\");")
+    application("polytope")
+    Polymake.shell_execute("require LPparser;")
 
     for app in call_function(:common, :startup_applications)
         application(app)

--- a/test/perlobj.jl
+++ b/test/perlobj.jl
@@ -217,6 +217,18 @@
         @test p.MILP.MINIMAL_VALUE == -7
     end
 
+    @testset "poly2lp2poly" begin
+        p = polytope.Polytope( INEQUALITIES=[1 1 -1; -1 0 1; 7 -1 -1] )
+        lp = polytope.LinearProgram(LINEAR_OBJECTIVE=[0,1,1])
+        p.LP = lp
+        x = mktemp() do path, _
+           @test Polymake.polytope.poly2lp(p,lp, false, path) == 1
+           return Polymake.polytope.lp2poly(path)
+        end
+        @test x isa Polymake.BigObject
+        @test p.LP.LINEAR_OBJECTIVE == x.LP.LINEAR_OBJECTIVE
+    end
+
     @testset "toplevel visual" begin
         @test visual(polytope.cube(3)) isa Polymake.Visual
     end


### PR DESCRIPTION
This works around an issue where the `LPparser` perl-module cannot be found.

It seems to be caused by a failure to adjust the `@INC` path when trying to load a module from within a function in `polytope` while the currently active application is `common`.