### PR TITLE
improve and unify save+load, add access to shell variables

### DIFF
--- a/src/polymake/julia.rules
+++ b/src/polymake/julia.rules
@@ -78,3 +78,19 @@ function deserialize_json_string($) {
    my $hash = decode_json($str);
    return Core::Serializer::deserialize($hash);
 }
+
+package Polymake::User;
+
+function get_shell_scalar($) {
+   my ($varname) = @_;
+   no strict 'refs';
+   return ${"Polymake::User::$varname"};
+}
+
+function set_shell_scalar($,$) {
+   my ($varname, $obj) = @_;
+   # redeclaring an existing variable will fail but we can just ignore that
+   eval "declare \$$varname;";
+   no strict 'refs';
+   ${"Polymake::User::$varname"} = $obj;
+}

--- a/src/repl.jl
+++ b/src/repl.jl
@@ -7,12 +7,12 @@
 import REPL
 import REPL: LineEdit, REPLCompletions
 
-struct Shell
-end
+struct ShellHelper end
+const Shell = ShellHelper()
 
-Base.getproperty(::Type{Shell}, name::Symbol) = Polymake.call_function(:User, :get_shell_scalar, String(name))
+Base.getproperty(::ShellHelper, name::Symbol) = Polymake.call_function(:User, :get_shell_scalar, String(name))
 
-Base.setproperty!(::Type{Shell}, name::Symbol, value) = Polymake.call_function(:User, :set_shell_scalar, String(name), value)
+Base.setproperty!(::ShellHelper, name::Symbol, value) = Polymake.call_function(:User, :set_shell_scalar, String(name), value)
 
 
 struct PolymakeCompletions <: LineEdit.CompletionProvider end

--- a/src/repl.jl
+++ b/src/repl.jl
@@ -7,6 +7,14 @@
 import REPL
 import REPL: LineEdit, REPLCompletions
 
+struct Shell
+end
+
+Base.getproperty(::Type{Shell}, name::Symbol) = Polymake.call_function(:User, :get_shell_scalar, String(name))
+
+Base.setproperty!(::Type{Shell}, name::Symbol, value) = Polymake.call_function(:User, :set_shell_scalar, String(name), value)
+
+
 struct PolymakeCompletions <: LineEdit.CompletionProvider end
 
 _color(str, magic_number=37) = Base.text_colors[(sum(Int, str) + magic_number) % 0xff]

--- a/src/util.jl
+++ b/src/util.jl
@@ -119,3 +119,25 @@ function prefer(label_expression::String)
     Base.depwarn("`prefer(label)` is deprecated, use `prefer(label) do ... end` instead.", :prefer, force=true)
     set_preference(label_expression)
 end
+
+function save_data(obj::SmallObject, filename::String, canonical::Bool)
+   Polymake.call_function(:User, :save_data, obj, filename, "canonical", canonical)
+   nothing
+end
+
+# there is also another save_bigobject function coming from the CxxWrap interface
+# but that one does not support the canonical option
+function save_bigobject(obj::BigObject, filename::String, canonical::Bool)
+   Polymake.call_function(:User, :save, obj, filename, "canonical", canonical)
+   nothing
+end
+
+# this allows loading bigobjects as well
+function load_data(filename::String)
+   return Polymake.call_function(:User, :load_data, filename)
+end
+
+load(filename::String) = load_data(filename)
+
+save(obj::SmallObject, filename::String; canonical=false) = save_data(obj, filename, canonical)
+save(obj::BigObject, filename::String; canonical=false) = save_bigobject(obj, filename, canonical)

--- a/test/perlobj.jl
+++ b/test/perlobj.jl
@@ -157,16 +157,6 @@
         @test Base.propertynames(g) isa Base.Vector{Symbol}
     end
 
-    @testset "save load" begin
-        test_polytope = @pm polytope.Polytope(POINTS=points_int)
-        mktempdir() do path
-            Polymake.save_bigobject(test_polytope,joinpath(path,"test.poly"))
-            loaded = Polymake.load_bigobject(joinpath(path,"test.poly"))
-            @test loaded isa Polymake.BigObject
-            @test Base.propertynames(test_polytope) == Base.propertynames(loaded)
-        end
-    end
-
     @testset "polymake tutorials" begin
         p = @pm polytope.Polytope(POINTS=polytope.cube(4).VERTICES)
         @test p isa Polymake.BigObject

--- a/test/util.jl
+++ b/test/util.jl
@@ -18,4 +18,60 @@
         @test common.incl(scdd,slrs) == 0
         @test_throws Polymake.PolymakeError Polymake.prefer("nonexistentlabel") do print end
     end
+
+    @testset "save load" begin
+        test_polytope = @pm polytope.Polytope(INEQUALITIES=facets)
+        mat = test_polytope.VERTICES
+        vec = test_polytope.F_VECTOR
+        mktempdir() do path
+            Polymake.save_bigobject(test_polytope,joinpath(path,"test.poly"))
+            loaded = Polymake.load_bigobject(joinpath(path,"test.poly"))
+            @test loaded isa Polymake.BigObject
+            @test test_polytope.VERTICES == loaded.VERTICES
+
+            Polymake.save(test_polytope,joinpath(path,"test.poly"); canonical=true)
+            loaded = Polymake.load(joinpath(path,"test.poly"))
+            @test loaded isa Polymake.BigObject
+            @test test_polytope.INEQUALITIES == loaded.INEQUALITIES
+
+            Polymake.save(mat,joinpath(path,"mat.pdata"); canonical=true)
+            loadedmat = Polymake.load(joinpath(path,"mat.pdata"))
+            @test loadedmat == mat
+
+            Polymake.save(vec,joinpath(path,"vec.pdata"); canonical=false)
+            loadedvec = Polymake.load(joinpath(path,"vec.pdata"))
+            @test loadedvec == vec
+        end
+    end
+
+    @testset "shell vars" begin
+        test_polytope = @pm polytope.Polytope(INEQUALITIES=facets)
+
+        Polymake.Shell.myvar = "Hello "
+        Polymake.shell_execute(raw"""$myvar .= "World!";""")
+        @test Polymake.Shell.myvar == "Hello World!"
+
+        # bigobject is just a pointer, so modifying it in the shell will modify
+        # the original object as well
+        @test !Polymake.exists(test_polytope, "F_VECTOR")
+        Polymake.Shell.poly = test_polytope
+        Polymake.shell_execute(raw"""$poly->F_VECTOR;""")
+        @test Polymake.exists(Polymake.Shell.poly,"F_VECTOR")
+
+        # small objects will also be passed via pointer
+        mat = test_polytope.VERTICES
+        Polymake.Shell.mat = mat
+        Polymake.shell_execute(raw"""$mat->elem(0,0)=5;""")
+        newmat = Polymake.Shell.mat
+        @test mat == newmat
+
+        # but at least for now they will be returned as a copy
+        Polymake.shell_execute(raw"""$mat->elem(0,0)=11;""")
+        @test mat != newmat
+        @test mat == Polymake.Shell.mat
+
+        # due to the way this variable access works, accessing non-existing
+        # will not throw an error but just return nothing
+        @test Polymake.Shell.notexisting == nothing
+    end
 end


### PR DESCRIPTION
Add `save_data` and `load_data`, add variant for `save_bigobject` with `canonical` JSON output.
Unify all save + load functions to `save` and `load` supporting small and big object types.

Add a fake module mapping the polymake shell variables (for people who need stuff that is not interfaced yet):
```julia
julia> Polymake.Shell.a = "Hello"
"Hello"

julia> Polymake.shell_execute(raw"""$a .= " World!";""");

julia> Polymake.Shell.a
"Hello World!"
```