### PR TITLE
included BigObject in Array_suppT

### DIFF
--- a/src/arrays.jl
+++ b/src/arrays.jl
@@ -5,7 +5,8 @@ const Array_suppT = Union{Int64, CxxWrap.CxxLong,
                         StdList{StdPair{CxxWrap.CxxLong,CxxWrap.CxxLong}},
                         Set{Int64}, Set{CxxWrap.CxxLong},
                         Array{Int64}, Array{CxxWrap.CxxLong},
-                        Array{Integer}, Array{Rational}, Matrix{Integer}}
+                        Array{Integer}, Array{Rational}, Matrix{Integer},
+                        BigObject}
 
 function Array{T}(::UndefInitializer, n::Base.Integer) where
     T <: Array_suppT


### PR DESCRIPTION
For Oscar issue 772 and general compatibility it is helpful to include `BigObject` in the constant `Array_suppT` so basic functionality for `Array{BigObject}` is accessible.