### PR TITLE
fixed interface for sparsevectors

### DIFF
--- a/src/sparsevector.jl
+++ b/src/sparsevector.jl
@@ -43,10 +43,14 @@ Base.@propagate_inbounds function Base.setindex!(V::SparseVector{T}, val, n::Bas
 end
 
 function findnz(vec::SparseVector{T}) where T
-    I = Int[to_one_based_indexing(i) for i in _nzindices(vec)]
+    I = SparseArrays.nonzeroinds(vec)
     V = to_jl_type(T)[vec[idx] for idx in I]
     return (I, V)
 end
+
+SparseArrays.nonzeroinds(vec::SparseVector) = Int[to_one_based_indexing(i) for i in _nzindices(vec)]
+
+SparseArrays.nonzeros(vec::SparseVector{T}) where T = findnz(vec)[2]
 
 # implementation of SparseVector{Bool} with Int64 length using a polymake Set
 struct SparseVectorBool <: SparseVector{Bool}

--- a/test/sparsevector.jl
+++ b/test/sparsevector.jl
@@ -299,5 +299,7 @@ using SparseArrays
         pe, pv = findnz(psv)
         @test je == pe
         @test jv == pv
+        @test nonzeroinds(psv) == je
+        @test nonzeros(psv) == jv
     end
 end

--- a/test/sparsevector.jl
+++ b/test/sparsevector.jl
@@ -299,7 +299,7 @@ using SparseArrays
         pe, pv = findnz(psv)
         @test je == pe
         @test jv == pv
-        @test nonzeroinds(psv) == je
-        @test nonzeros(psv) == jv
+        @test SparseArrays.nonzeroinds(psv) == je
+        @test SparseArrays.nonzeros(psv) == jv
     end
 end


### PR DESCRIPTION
Additionally to `findnz` a sparse vector needs `nonzeroinds` and `nonzeros`.