### PR TITLE
CI: run oscar with doctests on 1.6

### DIFF
--- a/.github/workflows/oscar.yml
+++ b/.github/workflows/oscar.yml
@@ -20,6 +20,7 @@ jobs:
     env:
       PR_NUMBER: ${{github.event.number}}
       JULIA_PKG_SERVER: ""
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
     - uses: actions/checkout@v2.1.0
     - name: "Set up Julia"
@@ -56,6 +57,7 @@ jobs:
     env:
       PR_NUMBER: ${{github.event.number}}
       JULIA_PKG_SERVER: ""
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     strategy:
       matrix: ${{fromJSON(needs.generatematrix.outputs.matrix)}}
       fail-fast: false
@@ -90,8 +92,17 @@ jobs:
                                  active_repo=\"${GITHUB_REPOSITORY}\");
                    github_env_runtests(meta;
                                        varname=\"oscar_run_tests\",
-                                       filename=\"${GITHUB_ENV}\");"
+                                       filename=\"${GITHUB_ENV}\");
+                   github_env_run_doctests(meta;
+                                           varname=\"oscar_run_doctests\",
+                                           filename=\"${GITHUB_ENV}\");"
+
       - name: "Run tests"
         run: |
           echo '${{ env.oscar_run_tests }}'
           julia --project=oscar-dev/project/ -e '${{ env.oscar_run_tests }}'
+      - name: "Run doctests"
+        if: matrix.julia-version == '~1.6.0-0' || matrix.julia-version == '1.6'
+        run: |
+          echo '${{ env.oscar_run_doctests }}'
+          julia --project=oscar-dev/project/ -e '${{ env.oscar_run_doctests }}'


### PR DESCRIPTION
To make use of https://github.com/oscar-system/OscarDevTools.jl/pull/18