### PR TITLE
CI: update codecov/codecov-action to v2

### DIFF
--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -55,7 +55,7 @@ jobs:
         run: mongorestore --host localhost -u admin -p admin --port 27017 .github/polydb_dump
       - uses: julia-actions/julia-runtest@latest
       - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v2
         with:
           file: ./lcov.info
           flags: unittests
@@ -98,7 +98,7 @@ jobs:
         run: echo "DEVELOPER_DIR=/Applications/Xcode_${{ matrix.xcode }}.app/Contents/Developer" >> $GITHUB_ENV
       - uses: julia-actions/julia-runtest@latest
       - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v2
         with:
           file: ./lcov.info
           flags: unittests


### PR DESCRIPTION
v1 will be disabled February 1, 2022; see https://github.com/codecov/codecov-action
