### PR TITLE
Add support for type of FUNDAMENTAL_GROUP

### DIFF
--- a/src/std/lists.jl
+++ b/src/std/lists.jl
@@ -1,21 +1,23 @@
-Base.eltype(::StdList{StdPair{T, T}}) where T = Pair{T,T}
+Base.eltype(::StdList{StdPair{S, T}}) where {S, T} = Pair{T,T}
 
-function Base.iterate(L::StdList)
+Base.push!(L::StdList{<:StdPair}, a::Pair) = push!(L, StdPair(a))
+
+Base.eltype(::StdList{T}) where T = T
+
+function Base.iterate(L::StdList{T}) where T
     isempty(L) &&  return nothing
     state = beginiterator(L)
     elt = get_element(state)
     increment(state)
-    return Pair(elt), state
+    return elt, state
 end
 
-function Base.iterate(L::StdList, state)
+function Base.iterate(L::StdList{T}, state) where T
     if isdone(L, state)
         return nothing
     else
         elt = get_element(state)
         increment(state)
-        return Pair(elt), state
+        return elt, state
     end
 end
-
-Base.push!(L::StdList{<:StdPair}, a::Pair) = push!(L, StdPair(a))

--- a/src/std/lists.jl
+++ b/src/std/lists.jl
@@ -1,10 +1,10 @@
-Base.eltype(::StdList{StdPair{S, T}}) where {S, T} = Pair{T,T}
+Base.eltype(::StdList{StdPair{S, T}}) where {S, T} = Pair{S,T}
 
 Base.push!(L::StdList{<:StdPair}, a::Pair) = push!(L, StdPair(a))
 
 Base.eltype(::StdList{T}) where T = T
 
-function Base.iterate(L::StdList{T}) where T
+function Base.iterate(L::StdList)
     isempty(L) &&  return nothing
     state = beginiterator(L)
     elt = get_element(state)
@@ -12,7 +12,7 @@ function Base.iterate(L::StdList{T}) where T
     return elt, state
 end
 
-function Base.iterate(L::StdList{T}, state) where T
+function Base.iterate(L::StdList, state)
     if isdone(L, state)
         return nothing
     else

--- a/src/std/pairs.jl
+++ b/src/std/pairs.jl
@@ -4,7 +4,7 @@ StdPair(p::Pair) = StdPair(first(p), last(p))
 Base.Pair(p::StdPair) = Pair(first(p), last(p))
 Base.Pair{S, T}(p::StdPair) where {S, T} = Pair{S, T}(first(p), last(p))
 Base.convert(::Type{<:Pair{T,S}}, p::StdPair) where {T,S} =
-    Pair(T(first(p)), S(last(p)))
+    Pair{T,S}(T(first(p)), S(last(p)))
 
 Base.length(p::StdPair) = 2
 Base.eltype(p::StdPair{T,T}) where T = T

--- a/src/std/pairs.jl
+++ b/src/std/pairs.jl
@@ -11,3 +11,5 @@ Base.eltype(p::StdPair{T,T}) where T = T
 Base.iterate(p::StdPair) = first(p), Val{:first}()
 Base.iterate(p::StdPair, ::Val{:first}) = last(p), Val{:last}()
 Base.iterate(p::StdPair, ::Val{:last}) = nothing
+
+Base.:(==)(p::Union{StdPair{S, T}, Pair{S, T}}, q::Union{StdPair{U, V}, Pair{U, V}}) where {S, T, U, V} = convert(Pair{S, T}, p) == convert(Pair{U, V}, q)

--- a/src/util.jl
+++ b/src/util.jl
@@ -5,6 +5,7 @@ for f in [:to_one_based_indexing, :to_zero_based_indexing]
     @eval begin
         $f(itr) = $f.(itr)
         $f(s::S) where S<:Set = Set($f.(s))
+        $f(s::S) where S<:AbstractSet = S($f.(s))
     end
 end
 

--- a/test/pairs.jl
+++ b/test/pairs.jl
@@ -8,10 +8,27 @@
         p = Polymake.StdPair{CxxWrap.CxxLong, CxxWrap.CxxLong}(1,2) 
         @test Polymake.first(p) == 1
         @test Polymake.last(p) == 2
+        @test p == Polymake.StdPair{CxxWrap.CxxLong, CxxWrap.CxxLong}(1,2)
+        @test p == Pair(1, 2)
     end
 
     @testset "High-level operations" begin
         p = Polymake.StdPair{CxxWrap.CxxLong, CxxWrap.CxxLong}(1,2) 
         @test +(p...) == 3
     end
+    
+    @testset "FUNDAMENTAL_GROUP" begin
+        t = Polymake.topaz.torus()
+        p1 = t.FUNDAMENTAL_GROUP
+        @test p1 isa Polymake.StdPair{CxxWrap.CxxLong, Polymake.StdList{Polymake.StdList{Polymake.StdPair{CxxWrap.CxxLong, CxxWrap.CxxLong}}}}
+        @test first(p1) == 15
+        r = last(p1)
+        @test r isa Polymake.StdList{Polymake.StdList{Polymake.StdPair{CxxWrap.CxxLong, CxxWrap.CxxLong}}}
+        @test length(r) == 14
+        l = collect(r)[13]
+        @test l isa Polymake.StdList{Polymake.StdPair{CxxWrap.CxxLong, CxxWrap.CxxLong}}
+        @test length(l) == 3
+        @test collect(l) == [4 => 1, 13 => 1, 11 => -1]
+    end
+    
 end


### PR DESCRIPTION
this required some small overhaul of lists, which previously only contained pairs of integers.

needs changes from branch of same name in `libpolymake_julia` to work.