### PR TITLE
Meta: remove `Polymake.` when parsing template types for functions calls

### DIFF
--- a/src/meta.jl
+++ b/src/meta.jl
@@ -53,7 +53,7 @@ function recursive_replace(str::AbstractString, replacement_pairs)
     return str
 end
 
-replace_braces(str) = recursive_replace(str, ["{"=>"<", "}"=>">"])
+replace_braces(str) = recursive_replace(str, ["{"=>"<", "}"=>">", "Polymake." => ""])
 
 function extract_args_kwargs(expr::Expr)
     kwarg_idx = findfirst(a -> a isa Expr && a.head == :kw, expr.args)

--- a/test/convert.jl
+++ b/test/convert.jl
@@ -38,6 +38,7 @@
         @test (@convert_to Array{Set{Int}} [Set([1, 2, 4, 5, 7, 8]), Set([1]), Set([6, 9])]) isa Polymake.Array{Polymake.Set{Polymake.to_cxx_type(Int64)}}
         @test (@convert_to Vector{Float} [10, 11, 12]) isa Polymake.Vector{Float64}
         @test (@convert_to Matrix{Rational} [10/1 11/1 12/1]) isa Polymake.Matrix{Polymake.Rational}
+        @test (@convert_to Polymake.Matrix{Polymake.Rational} [10/1 11/1 12/1]) isa Polymake.Matrix{Polymake.Rational}
         @test_throws LoadError eval(:(@convert_to Array{Set{Int}}))
         @test_throws LoadError eval(:(@convert_to Array{Set{Int}} [Set([1, 2, 4, 5, 7, 8]), Set([1]), Set([6, 9])] Set([4, 3])))
         err = try


### PR DESCRIPTION
allows something like this:
```
@convert_to Polymake.Vector{Polymake.Rational} someobject
```
which used to crash julia.

cc: @lkastner 