### PR TITLE
improve error messages for unsupported platforms

### DIFF
--- a/src/Polymake.jl
+++ b/src/Polymake.jl
@@ -56,7 +56,13 @@ end
 # Load Cxx stuff and init
 ##########################
 
-Sys.iswindows() && error("System is not supported!")
+Sys.iswindows() &&
+   error("""Windows is not supported, please try the Windows Subsystem for Linux.
+            For details please check: https://oscar.computeralgebra.de/install/""")
+
+libpolymake_julia_jll.is_available() ||
+   error("""This platform or julia version is currently not supported by Polymake:
+            $(Base.BinaryPlatforms.host_triplet())""")
 
 libcxxwrap_build_version() = VersionNumber(unsafe_string(ccall((:jlpolymake_libcxxwrap_build_version,libpolymake_julia), Cstring, ())))
 


### PR DESCRIPTION
x-ref: #394

Tests on nightly now print:
```
     Testing Running tests...
ERROR: LoadError: This platform or julia version is currently not supported by Polymake:
x86_64-linux-gnu-libgfortran4-cxx11-libstdcxx29-julia_version+1.9.0
```