### PR TITLE
honor --banner=no (and implicitly -q)

### DIFF
--- a/src/Polymake.jl
+++ b/src/Polymake.jl
@@ -116,7 +116,7 @@ function __init__()
     ENV["POLYMAKE_DEPS_TREE"] = polymake_deps_tree
 
     try
-        show_banner = isinteractive() &&
+        show_banner = isinteractive() && Base.JLOptions().banner != 0 &&
                        !any(x->x.name in ["Oscar"], keys(Base.package_locks))
 
         initialize_polymake(show_banner)


### PR DESCRIPTION
`-q` will automatically set `banner=0`. Unless `--banner=yes` is explicitly requested, in which case we will keep printing the banner.

cc: @fingolfin @thofma 