### PR TITLE
Workaround for broken nightly tests

### DIFF
--- a/src/Polymake.jl
+++ b/src/Polymake.jl
@@ -11,7 +11,7 @@ module Polymake
 export @pm, @convert_to, visual
 
 # We need to import all functions which will be extended on the Cxx side
-import Base: ==, <, <=, *, -, +, //, ^, div, rem, one, zero,
+import Base: ==, <, <=, *, -, +, /, //, ^, div, rem, one, zero,
     append!, deepcopy_internal, delete!, numerator, denominator,
     empty!, Float64, getindex, in, intersect, intersect!, isempty,
     length, numerator, push!, resize!,

--- a/src/incidencematrix.jl
+++ b/src/incidencematrix.jl
@@ -50,7 +50,7 @@ function IncidenceMatrix{Symmetric}(mat::AbstractSparseMatrix)
     return res
 end
 
-function IncidenceMatrix{NonSymmetric}(incidenceRows::AbstractVector{<:AbstractVector{<:Base.Integer}}) where T
+function IncidenceMatrix{NonSymmetric}(incidenceRows::AbstractVector{<:AbstractVector{<:Base.Integer}})
     m = length(incidenceRows)
     n = maximum(maximum, incidenceRows)
     res = IncidenceMatrix(m, n)

--- a/src/sparsevector.jl
+++ b/src/sparsevector.jl
@@ -42,7 +42,7 @@ Base.@propagate_inbounds function Base.setindex!(V::SparseVector{T}, val, n::Bas
     return val
 end
 
-function findnz(vec::SparseVector{T}) where T
+function SparseArrays.findnz(vec::SparseVector{T}) where T
     I = SparseArrays.nonzeroinds(vec)
     V = to_jl_type(T)[vec[idx] for idx in I]
     return (I, V)
@@ -115,4 +115,22 @@ function Base.show(io::IOContext, ::MIME"text/plain", V::SparseVectorBool)
         print(io, ", …")
     end
     print(io, "]")
+end
+
+function Base.:*(a::Number, sv::SparseVector{T}) where T<:VecOrMat_eltypes
+    res = spzeros(convert_to_pm_type(promote_type(T, typeof(a))), length(sv))
+    for idx in SparseArrays.nonzeroinds(sv)
+        res[idx] = a * sv[idx]
+    end
+    return res
+end
+
+Base.:*(sv::SparseVector, a::Number) = a * sv
+
+function Base.:/(sv::SparseVector{Float64}, a::Number)
+    res = spzeros(Float64, length(sv))
+    for idx in SparseArrays.nonzeroinds(sv)
+        res[idx] = sv[idx] / a
+    end
+    return res
 end


### PR DESCRIPTION
The tests with the nightly version of julia currently fail due to a wrong fallback for scalar multiplication and division. While this most probably will be fixed in the near future, this workaround also intends to improve performance.