### PR TITLE
CI: update some actions to latest versions

### DIFF
--- a/.github/workflows/createdocumentation.yml
+++ b/.github/workflows/createdocumentation.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2.1.0
+      - uses: actions/checkout@v3
       - name: "Set up Julia"
         uses: julia-actions/setup-julia@v1
         with:

--- a/.github/workflows/oscar.yml
+++ b/.github/workflows/oscar.yml
@@ -22,7 +22,7 @@ jobs:
       JULIA_PKG_SERVER: ""
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-    - uses: actions/checkout@v2.1.0
+    - uses: actions/checkout@v3
     - name: "Set up Julia"
       uses: julia-actions/setup-julia@v1
       with:
@@ -63,7 +63,7 @@ jobs:
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v2.1.0
+      - uses: actions/checkout@v3
       - name: "Set up Julia"
         uses: julia-actions/setup-julia@v1
         with:

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -47,7 +47,7 @@ jobs:
       JULIA_PKG_SERVER: ""
       POLYDB_TEST_URI: "mongodb://admin:admin@localhost:27017/?authSource=admin"
     steps:
-      - uses: actions/checkout@v2.1.0
+      - uses: actions/checkout@v3
       - name: "Set up Julia"
         uses: julia-actions/setup-julia@v1
         with:
@@ -87,7 +87,7 @@ jobs:
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v2.1.0
+      - uses: actions/checkout@v3
       - name: "Set up Julia"
         uses: julia-actions/setup-julia@v1
         with:


### PR DESCRIPTION
GitHub warns that this is needed because they are updating from Node 12 to 16
