### PR TITLE
windows: use wslviewer script for native visualization

### DIFF
--- a/src/Polymake.jl
+++ b/src/Polymake.jl
@@ -130,6 +130,16 @@ function __init__()
     application("common")
     shell_execute("include(\"$(joinpath(@__DIR__, "polymake", "julia.rules"))\");")
 
+    # try using wslviewer to open threejs / svg / pdf properly on WSL
+    # Note: the binfmt_misc check might not detect all cases of wsl but we need exactly
+    # that feature enabled to be able to launch a windows process for the visualization
+    # alternative check might be: WSL2 occuring in /proc/sys/kernel/osrelease
+    if Sys.islinux() && isfile("/proc/sys/fs/binfmt_misc/WSLInterop")
+        shell_execute("script(\"$(joinpath(@__DIR__, "polymake", "wslviewer.pl"))\");")
+        shell_execute(raw"""application("common")->configured->{"webbrowser.rules"} > 0 or reconfigure("webbrowser.rules");""")
+        shell_execute(raw"""application("common")->configured->{"pdfviewer.rules"} > 0 or reconfigure("pdfviewer.rules");""")
+    end
+
     # work around issue with lp2poly and looking up perl modules from different applications
     application("polytope")
     Polymake.shell_execute("require LPparser;")

--- a/src/polymake/wslviewer.pl
+++ b/src/polymake/wslviewer.pl
@@ -1,0 +1,35 @@
+use application "common";
+
+set_custom $Visual::webbrowser="/usr/bin/wslview";
+set_custom $Visual::pdfviewer="/usr/bin/wslview";
+
+*ThreeJS::Viewer::command = sub {
+   my ($self, $filename) = @_;
+   chomp(my $res = `wslpath -m $Polymake::Resources`);
+   $res =~ s/\$/\\\$/g;
+   system("perl -pi -e 's{$Polymake::Resources}{file:///$res}g' $filename");
+   chomp(my $wslfilename = "file:///".`wslpath -m $filename`);
+   "$Visual::webbrowser $wslfilename < /dev/null";
+};
+
+
+*TikZ::Viewer::command = sub {
+   my ($self, $filename)=@_;
+   my $latextemplate = $self->tempfile.".tex";
+   open my $fh, ">", $latextemplate;
+   print $fh TikZ::Viewer::write_latextemplate("$filename");
+   close $fh;
+   my $pdfout_dir = $self->tempfile->dirname;
+   my $pdfout_name = $self->tempfile->basename;
+   chomp(my $wslfilename = "file:///".`wslpath -m $latextemplate`);
+   $wslfilename =~ s/\.tex/.pdf/;
+   "$Visual::pdflatex -interaction=batchmode --output-directory=$pdfout_dir --jobname=$pdfout_name $latextemplate 1>/dev/null; $Visual::pdfviewer $wslfilename < /dev/null";
+};
+
+
+*PmSvg::Viewer::command = sub {
+   my ($self, $filename) = @_;
+   chomp(my $wslfilename = "file:///".`wslpath -m $filename`);
+   "$Visual::webbrowser $wslfilename < /dev/null";
+};
+


### PR DESCRIPTION
should fix https://github.com/oscar-system/Oscar.jl/issues/1615 (the non-working visualize on WSL), the crash was already fixed with #408.