### PR TITLE
wslview: make configuration more robust

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Polymake"
 uuid = "d720cf60-89b5-51f5-aff5-213f193123e7"
 repo = "https://github.com/oscar-system/Polymake.jl.git"
-version = "0.8.3"
+version = "0.8.4"
 
 [deps]
 BinaryWrappers = "f01c122e-0ea1-4f85-ad8f-907073ad7a9f"

--- a/src/Polymake.jl
+++ b/src/Polymake.jl
@@ -135,14 +135,12 @@ function __init__()
     # that feature enabled to be able to launch a windows process for the visualization
     # alternative check might be: WSL2 occuring in /proc/sys/kernel/osrelease
     if Sys.islinux() && isfile("/proc/sys/fs/binfmt_misc/WSLInterop")
-        shell_execute("script(\"$(joinpath(@__DIR__, "polymake", "wslviewer.pl"))\");")
-        shell_execute(raw"""application("common")->configured->{"webbrowser.rules"} > 0 or reconfigure("webbrowser.rules");""")
-        shell_execute(raw"""application("common")->configured->{"pdfviewer.rules"} > 0 or reconfigure("pdfviewer.rules");""")
+        configure_wslview(force=false);
     end
 
     # work around issue with lp2poly and looking up perl modules from different applications
     application("polytope")
-    Polymake.shell_execute("require LPparser;")
+    shell_execute("require LPparser;")
 
     for app in call_function(:common, :startup_applications)
         application(app)

--- a/src/polymake/wslviewer.pl
+++ b/src/polymake/wslviewer.pl
@@ -1,35 +1,90 @@
 use application "common";
 
-set_custom $Visual::webbrowser="/usr/bin/wslview";
-set_custom $Visual::pdfviewer="/usr/bin/wslview";
+sub configure_wsl
+{
+   my ($rule, $force) = @_;
 
-*ThreeJS::Viewer::command = sub {
-   my ($self, $filename) = @_;
-   chomp(my $res = `wslpath -m $Polymake::Resources`);
-   $res =~ s/\$/\\\$/g;
-   system("perl -pi -e 's{$Polymake::Resources}{file:///$res}g' $filename");
-   chomp(my $wslfilename = "file:///".`wslpath -m $filename`);
-   "$Visual::webbrowser $wslfilename < /dev/null";
-};
+   # is_changed should be true here if some autoconfiguration happened during startup
+   unless ($force || (exists $Settings->items->{"Visual::$rule"} &&
+                      $Settings->items->{"Visual::$rule"}->flags & Item::Flags::is_changed)) {
+      # we keep the existing setting
+      print("wslviewer.pl: keeping existing $rule setting\n");
+      return true;
+   }
+
+   if (!-e "/usr/bin/wslview") {
+      state $warned = 0;
+      if ($force || !$warned) {
+         warn("/usr/bin/wslview not found, to use native viewers for
+         visualization on Windows (with WSL) please install wslview
+         and run `Polymake.configure_wslview()` afterwards.\n");
+         $warned = 1;
+      }
+      return false;
+   }
+
+   # this should make sure the custom variable exists
+   application("common")->configured->{"$rule.rules"} > 0 or reconfigure("$rule.rules");
+
+   eval("set_custom \$Visual::$rule='/usr/bin/wslview';
+         print('wslviewer.pl: set $rule custom variable for wslview\n');");
+   if ($@) {
+      warn("wslviewer.pl: setting wslview for $rule failed $@.");
+      return false;
+   }
+
+   # make sure rules are active
+   application("common")->configured->{"$rule.rules"} > 0 or reconfigure("$rule.rules");
+   return true;
+}
+
+sub wsl_redirect_webbrowser
+{
+   unless (application("common")->configured->{"webbrowser.rules"} > 0 &&
+           $Visual::webbrowser eq "/usr/bin/wslview") {
+      print("wslviewer.pl: expected webbrowser to be configured for wsl.\n");
+      return 0;
+   }
+   print("wslviewer.pl: redirecting threejs sub\n");
+   *ThreeJS::Viewer::command = sub {
+      my ($self, $filename) = @_;
+      chomp(my $res = `wslpath -m $Polymake::Resources`);
+      $res =~ s/\$/\\\$/g;
+      system("perl -pi -e 's{$Polymake::Resources}{file:///$res}g' $filename");
+      chomp(my $wslfilename = "file:///".`wslpath -m $filename`);
+      "$Visual::webbrowser $wslfilename < /dev/null";
+   };
+
+   print("wslviewer.pl: redirecting svg sub\n");
+   *PmSvg::Viewer::command = sub {
+      my ($self, $filename) = @_;
+      chomp(my $wslfilename = "file:///".`wslpath -m $filename`);
+      "$Visual::webbrowser $wslfilename < /dev/null";
+   };
+}
 
 
-*TikZ::Viewer::command = sub {
-   my ($self, $filename)=@_;
-   my $latextemplate = $self->tempfile.".tex";
-   open my $fh, ">", $latextemplate;
-   print $fh TikZ::Viewer::write_latextemplate("$filename");
-   close $fh;
-   my $pdfout_dir = $self->tempfile->dirname;
-   my $pdfout_name = $self->tempfile->basename;
-   chomp(my $wslfilename = "file:///".`wslpath -m $latextemplate`);
-   $wslfilename =~ s/\.tex/.pdf/;
-   "$Visual::pdflatex -interaction=batchmode --output-directory=$pdfout_dir --jobname=$pdfout_name $latextemplate 1>/dev/null; $Visual::pdfviewer $wslfilename < /dev/null";
-};
+sub wsl_redirect_pdfviewer
+{
+   unless (application("common")->configured->{"pdfviewer.rules"} > 0 && 
+           $Visual::pdfviewer eq "/usr/bin/wslview") {
+      print("wslviewer.pl: expected pdfviewer to be configured for wsl.\n");
+      return 0;
+   }
+   print("wslviewer.pl: redirecting tikz sub\n");
+   *TikZ::Viewer::command = sub {
+      my ($self, $filename)=@_;
+      my $latextemplate = $self->tempfile.".tex";
+      open my $fh, ">", $latextemplate;
+      print $fh TikZ::Viewer::write_latextemplate("$filename");
+      close $fh;
+      my $pdfout_dir = $self->tempfile->dirname;
+      my $pdfout_name = $self->tempfile->basename;
+      chomp(my $wslfilename = "file:///".`wslpath -m $latextemplate`);
+      $wslfilename =~ s/\.tex/.pdf/;
+      "$Visual::pdflatex -interaction=batchmode --output-directory=$pdfout_dir --jobname=$pdfout_name $latextemplate 1>/dev/null; $Visual::pdfviewer $wslfilename < /dev/null";
+   };
+}
 
-
-*PmSvg::Viewer::command = sub {
-   my ($self, $filename) = @_;
-   chomp(my $wslfilename = "file:///".`wslpath -m $filename`);
-   "$Visual::webbrowser $wslfilename < /dev/null";
-};
-
+configure_wsl("webbrowser", @_) && wsl_redirect_webbrowser();
+configure_wsl("pdfviewer", @_) && wsl_redirect_pdfviewer();

--- a/src/visual.jl
+++ b/src/visual.jl
@@ -139,3 +139,16 @@ function visual(obj::BigObject; kwargs...)
 end
 
 visual(::Type{Visual}, obj::BigObject; kwargs...) = call_method(obj, :VISUAL; kwargs...)
+
+
+function configure_wslview(; force=true)
+   (out, err) = shell_execute("script(\"$(joinpath(@__DIR__, "polymake", "wslviewer.pl"))\", $force);")
+   if force
+      isempty(err) || error(err)
+      isempty(out) || @info out
+   else
+      isempty(err) || @warn err
+      isempty(out) || @debug out
+   end
+   nothing
+end


### PR DESCRIPTION
fixes #417 

This will print the following once after autoconfiguration:
```
┌ Warning: /usr/bin/wslview not found, to use native viewers for
│          visualization on Windows (with WSL) please install wslview
│          and run `Polymake.configure_wslview()` afterwards.
└ @ Polymake ~/Polymake.jl/src/visual.jl:150
```
Subsequent starts of Polymake.jl will not print this warning, until it is updated, loaded from a different source directory, or the scratchspace is cleared.