### PR TITLE
Don't throw an error if `jupyter kernelspec` does not exist

### DIFF
--- a/src/ijulia.jl
+++ b/src/ijulia.jl
@@ -34,24 +34,30 @@ function prepare_jupyter_kernel_for_visualization()
    success = false
 
    # first try with kernelspec command
-   try
-      json = read(`$(Main.IJulia.find_jupyter_subcommand("kernelspec")) list --json`, String)
-      kernelspecs = JSON.parse(json)["kernelspecs"]
-
-      for (kernel, spec) in kernelspecs
-         if occursin("julia", kernel)
-            push!(kerneldirs, spec["resource_dir"])
-         end
+   kernelspecs = try
+      c = ignorestatus(`$(Main.IJulia.find_jupyter_subcommand("kernelspec")) list --json`)
+      err = Pipe()
+      # If there is no kernelspec command, this will return an empty string (but
+      # not throw an error because of ignorestatus)
+      json = read(pipeline(c, stderr = err), String)
+      close(err.in)
+      # If isempty(json), then JSON.parse will throw an error
+      JSON.parse(json)["kernelspecs"]
+   catch e
+      Dict{String, Any}()
+   end
+   for (kernel, spec) in kernelspecs
+      if occursin("julia", kernel)
+         push!(kerneldirs, spec["resource_dir"])
       end
-   finally
-      # if kernelspec failed or nothing was found
-      # we go through the directories in the IJulia kerneldir
-      if isempty(kerneldirs)
-         kerneldir = Main.IJulia.kerneldir()
-         for dir in readdir(kerneldir)
-            if isdir(joinpath(kerneldir, dir)) && startswith(dir, "julia")
-               push!(kerneldirs, joinpath(kerneldir, dir))
-            end
+   end
+   # if kernelspec failed or nothing was found
+   # we go through the directories in the IJulia kerneldir
+   if isempty(kerneldirs)
+      kerneldir = Main.IJulia.kerneldir()
+      for dir in readdir(kerneldir)
+         if isdir(joinpath(kerneldir, dir)) && startswith(dir, "julia")
+            push!(kerneldirs, joinpath(kerneldir, dir))
          end
       end
    end


### PR DESCRIPTION
Catch and ignore an error if the command `jupyter kernelspec` does not exist and redirect the corresponding `stderr` to nowhere.

Background: on my Debian 12 system, the command `jupyter kernelspec` does not exist. This results in a error/help message from jupyter and throws an `InitError` when I try to load Polymake (or Oscar) in a jupyter notebook.