### PR TITLE
Change an `@info` during precompilation to `@debug`

### DIFF
--- a/src/generate_applications.jl
+++ b/src/generate_applications.jl
@@ -9,7 +9,7 @@ jsondir = libpolymake_julia_jll.appsjson
 for (app, mod) in appname_module_dict
     json_file = joinpath(jsondir, "$app.json")
     @assert isfile(json_file)
-    @info "Generating module $mod"
+    @debug "Generating module $mod"
     @eval $(Polymake.Meta.jl_code(Polymake.Meta.PolymakeApp(mod, json_file)))
     @eval export $mod
 end


### PR DESCRIPTION
This avoids a "scary" warning in Julia 1.9 upwards:

    Precompiling project...
      31 dependencies successfully precompiled in 30 seconds. 25 already precompiled.
      1 dependency had warnings during precompilation:
    ┌ Polymake [d720cf60-89b5-51f5-aff5-213f193123e7]
    │  [ Info: Generating module common
    │  [ Info: Generating module ideal
    │  [ Info: Generating module graph
    │  [ Info: Generating module fulton
    │  [ Info: Generating module fan
    │  [ Info: Generating module group
    │  [ Info: Generating module polytope
    │  [ Info: Generating module topaz
    │  [ Info: Generating module tropical
    │  [ Info: Generating module matroid
    └
