### PR TITLE
repl: make repl init more robust

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Polymake"
 uuid = "d720cf60-89b5-51f5-aff5-213f193123e7"
 repo = "https://github.com/oscar-system/Polymake.jl.git"
-version = "0.9.1"
+version = "0.9.2"
 
 [deps]
 BinaryWrappers = "f01c122e-0ea1-4f85-ad8f-907073ad7a9f"

--- a/src/repl.jl
+++ b/src/repl.jl
@@ -92,6 +92,8 @@ global function run_polymake_repl(;
                      key = '$')
    repl = Base.active_repl
    mirepl = isdefined(repl,:mi) ? repl.mi : repl
+   # skip repl init if it is not fully loaded
+   isdefined(mirepl, :interface) && isdefined(mirepl.interface, :modes) || return nothing
    main_mode = mirepl.interface.modes[1]
 
    panel = CreatePolymakeREPL(; prompt=prompt, name=name, repl=repl)


### PR DESCRIPTION
avoid some UndefRefError during init without the julia repl fully loaded

(I don't really know why this problem did not show up previously)