### PR TITLE
Added `list_properties(::BigObject)`

### DIFF
--- a/src/perlobj.jl
+++ b/src/perlobj.jl
@@ -36,6 +36,11 @@ end
 
 Base.propertynames(p::BigObject) = Symbol.(Polymake.complete_property(p, ""))
 
+function list_properties(obj::BigObject)
+    l = Polymake.call_method(Polymake.PropertyValue, obj, :list_properties; calltype = :list)
+    return Polymake.to_array_string(l)
+end
+
 function Base.setproperty!(obj::BigObject, prop::Symbol, val)
     @assert prop != :cpp_object
     return take(obj, string(prop), convert(PolymakeType, val))

--- a/test/perlobj.jl
+++ b/test/perlobj.jl
@@ -122,7 +122,13 @@
 
     @testset verbose=true "properties" begin
         test_polytope = @pm polytope.Polytope(POINTS=points_int)
+        @test Polymake.list_properties(test_polytope) isa Polymake.Array
+        @test Polymake.list_properties(test_polytope) == ["POINTS"]
         @test test_polytope.F_VECTOR == [ 4, 4 ]
+        let prli = Polymake.list_properties(test_polytope)
+            @test "POINTS" in prli
+            @test "F_VECTOR" in prli
+        end
         @test test_polytope.INTERIOR_LATTICE_POINTS ==
             [ 1 1 1 ; 1 1 2 ; 1 2 1 ; 1 2 2 ]
 


### PR DESCRIPTION
`list_properties` is used to retrieve the names of every existing property of a `BigObject`, wherewas the already existing `propertynames(::BigObject)` returns a complete list of names of every possible (i.e. including any not yet computed) property of a `BigObject`