### PR TITLE
CI: use concrete action version

### DIFF
--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -61,7 +61,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y mongodb-database-tools
           mongorestore --host localhost -u admin -p admin --port 27017 .github/polydb_dump
-      - uses: julia-actions/julia-runtest@latest
+      - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v2
         with:
@@ -92,7 +92,7 @@ jobs:
         uses: julia-actions/setup-julia@v1
         with:
           version: ${{ matrix.julia-version }}
-      - uses: julia-actions/julia-runtest@latest
+      - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v2
         with:


### PR DESCRIPTION
https://github.com/oscar-system/Oscar.jl/pull/2770 for Polymake.jl. This is recommended by the [readme](https://github.com/julia-actions/julia-runtest#usage).