### PR TITLE
Small fix for `OptionSet` creation

### DIFF
--- a/src/perlobj.jl
+++ b/src/perlobj.jl
@@ -120,7 +120,7 @@ end
 function OptionSet(iter)
     opt_set = OptionSet()
     for (key, value) in iter
-        option_set_take(opt_set, string(key), value)
+        option_set_take(opt_set, string(key), convert(PolymakeType, value))
     end
     return opt_set
 end


### PR DESCRIPTION
The implicit conversion failed for a `Polymake.Vector{Float64}`, which can be used during visualization. This PR only introduces a small change to fix this: we now convert the value to a `PolymakeType` before calling `option_set_take`.

@benlorenz 