### PR TITLE
Allow AA 0.41

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -25,6 +25,7 @@ polymake_jll = "7c209550-9012-526c-9264-55ba7a78ba2c"
 polymake_oscarnumber_jll = "10f31823-b687-53e6-9f29-edb9d4da9f9f"
 
 [compat]
+AbstractAlgebra = "~0.40.8, ~0.41"
 BinaryWrappers = "~0.1.0"
 CxxWrap = "~0.14"
 Downloads = "^1.4"
@@ -44,4 +45,3 @@ lib4ti2_jll = "^1.6.10"
 libpolymake_julia_jll = "~0.11.1"
 polymake_jll = "^400.1100.1"
 polymake_oscarnumber_jll = "~0.2.7"
-AbstractAlgebra = "~0.40.8"


### PR DESCRIPTION
AbstractAlgebra released a breaking version. To still get the most recent Polymake.jl in Oscar once https://github.com/oscar-system/Oscar.jl/pull/3667 is merged, the AA compat needs to be updated.
Since Polymake.jl just needs the banner hiding code form AA, there is no breaking change affecting Polymake.jl, so we can keep compatibility with the older versions.