### PR TITLE
Provide a stale_age to mkpidlock

### DIFF
--- a/src/Polymake.jl
+++ b/src/Polymake.jl
@@ -247,7 +247,7 @@ function __init__()
                           !any(x->x.name in ["Oscar"], keys(Base.package_locks))
            mkpath(polymake_user_dir)
            # lock to avoid race-conditions when recompiling wrappers in multiple processes
-           Pidfile.mkpidlock("$(polymake_user_dir)/userdir.lock") do
+           Pidfile.mkpidlock("$(polymake_user_dir)/userdir.lock"; stale_age=60) do
                initialize_polymake_with_dir("$(polymake_extension_config);user=$(polymake_user_dir)", installtop, installarch, show_banner)
            end
            if !show_banner


### PR DESCRIPTION
Normally the pidlock should be held for just a few seconds; waiting for
its age to exceed 60 seconds until we consider it stale should be safe.
In fact Julia waits 5 times longer if the process creating the pid lock
file seems to be still running.

On the other hand, without a stale age, the lock file is *never*
considered stale, even if the process creating it definitely is gone,
and so the user can get stuck, which obviously is very bad. To get
unstuck they need to manually delete the lock file.



Actually, I am not completely sure if the limit I provide is "good",
so if you think something else is more appropriate, please don't
hesitate to just adjust the PR or ask me to adjust it.