### PR TITLE
Bump AbstractAlgebra compat to include 0.43

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -26,7 +26,7 @@ polymake_jll = "7c209550-9012-526c-9264-55ba7a78ba2c"
 polymake_oscarnumber_jll = "10f31823-b687-53e6-9f29-edb9d4da9f9f"
 
 [compat]
-AbstractAlgebra = "~0.40.8, ~0.41, ~0.42"
+AbstractAlgebra = "~0.40.8, ~0.41, ~0.42, ~0.43"
 BinaryWrappers = "~0.1.0"
 CxxWrap = "~0.14"
 Downloads = "^1.4"


### PR DESCRIPTION
Can we get a release with this?