### PR TITLE
Skip docs preview for dependabot PRs

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -9,7 +9,13 @@ makedocs(sitename = "Polymake.jl - Documentation",
                   "shell.md",
                  ])
 
+should_push_preview = true
+if get(ENV, "GITHUB_ACTOR", "") == "dependabot[bot]"
+    # skip preview for dependabot PRs as they fail due to lack of permissions
+    should_push_preview = false
+end
+
 deploydocs(
     repo = "github.com/oscar-system/Polymake.jl.git",
-    push_preview    = true,
+    push_preview = should_push_preview,
 )


### PR DESCRIPTION
If https://github.com/oscar-system/Polymake.jl/pull/506 is merged, this PR should be merged as well. Otherwise, CI jobs that try do build and deploy documentation will fail.

See https://github.com/oscar-system/Oscar.jl/pull/4554.