### PR TITLE
Allow AbstractAlgebra 0.45

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -26,7 +26,7 @@ polymake_jll = "7c209550-9012-526c-9264-55ba7a78ba2c"
 polymake_oscarnumber_jll = "10f31823-b687-53e6-9f29-edb9d4da9f9f"
 
 [compat]
-AbstractAlgebra = "~0.40.8, ~0.41, ~0.42, ~0.43, ~0.44"
+AbstractAlgebra = "~0.40.8, ~0.41, ~0.42, ~0.43, ~0.44, ~0.45"
 BinaryWrappers = "~0.1.0"
 CxxWrap = "~0.14, ~0.16"
 Downloads = "^1.4"


### PR DESCRIPTION
The new version should contain no changes that are breaking for GAP.jl.

@benlorenz  could you please prepare a patch release with this? (we want to get the new AA into Oscar before 1.4)

You could also do a breaking release containing https://github.com/oscar-system/Polymake.jl/pull/505 if you want to. I'll need to take care of fixing the doctests and booktests due to other printing changes in Hecke anyway.