### PR TITLE
stops stack overflow when edge map values are QQFieldelem

### DIFF
--- a/src/convert.jl
+++ b/src/convert.jl
@@ -121,7 +121,7 @@ const DirType = Union{Directed, Undirected}
 convert_to_pm_type(::Type{<:Graph{T}}) where T<:DirType = Graph{T}
 
 convert_to_pm_type(::Type{<:EdgeMap{S,T}}) where S<:DirType where T = EdgeMap{S, convert_to_pm_type(T)}
-EdgeMap{Dir, T}(g::Graph{Dir}) where Dir<:DirType where T = EdgeMap{Dir,to_cxx_type(T)}(g)
+EdgeMap{Dir, T}(g::Graph{Dir}) where Dir<:DirType where T = EdgeMap{Dir,convert_to_pm_type(T)}(g)
 
 convert_to_pm_type(::Type{<:NodeMap{S,T}}) where S <: DirType where T = NodeMap{S, convert_to_pm_type(T)}
 NodeMap{Dir, T}(g::Graph{Dir}) where Dir<:DirType where T = NodeMap{Dir,to_cxx_type(T)}(g)

--- a/test/graphs.jl
+++ b/test/graphs.jl
@@ -58,6 +58,12 @@
         em[1, 2] = 1
         @test em[1, 2] == em[(1, 2)] == 1
         @test em[2, 3] == 0
+
+        em2 = Polymake.EdgeMap{Polymake.Directed, Rational}(g)
+        @test em2 isa Polymake.EdgeMap
+        em2[1, 2] = 1//2
+        @test em2[1, 2] == em2[(1, 2)] == 1//2
+        @test em2[2, 3] == 0
     end
 
     @testset verbose=true "NodeMap" begin


### PR DESCRIPTION
I am not sure if this is the best solution, but it seems to fix my issue.

i.e. this works now, where it used to lead to a stack overflow

```
julia> tree = graph_from_edges(Directed,[[4,1],[4,2],[4,3], [5, 4], [5, 6]])
Directed graph with 6 nodes and the following edges:
(4, 1)(4, 2)(4, 3)(5, 4)(5, 6)

julia> label!(tree, Dict{NTuple{2, Int}, QQFieldElem}((5, 6) => 1,
       (5, 4) => 2,
       (4, 1) => 3,
       (4, 2) => 4,
       (4, 3) => 5//3), nothing; name=:distance)
Directed graph with 6 nodes and the following labeling(s):
label: distance
(4, 1) -> 3
(4, 2) -> 4
(4, 3) -> 5/3
(5, 4) -> 2
(5, 6) -> 1
```