### PR TITLE
add cleanup queue for perl based objects

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Polymake"
 uuid = "d720cf60-89b5-51f5-aff5-213f193123e7"
 repo = "https://github.com/oscar-system/Polymake.jl.git"
-version = "0.13.6"
+version = "0.13.7"
 
 [deps]
 AbstractAlgebra = "c3fe647b-3220-5bb0-a1ea-a7954cac585d"

--- a/src/Polymake.jl
+++ b/src/Polymake.jl
@@ -209,7 +209,7 @@ function __init__()
     mkpath(target(extarch))
 
     for (ext, dirname) in extensions
-       src(name...) = joinpath(ext.artifact_dir, name...)
+       src(name...) = joinpath(ext.find_artifact_dir(), name...)
        force_symlink(src(exttop, dirname), target(exttop, dirname))
        force_symlink(src(extarch, dirname), target(extarch, dirname))
        push!(extensionpaths, target(exttop, dirname))
@@ -307,7 +307,69 @@ function __init__()
     # the data will be cleaned anyway once the iddict is cleared
     Base.atexit() do
         Polymake.oscarnumber_prepare_cleanup()
+        ccall(:jl_safe_printf, Cvoid, (Cstring, ), "cleanup: $(_count_run[]), $(_count_clean[]), $(_count_cleanobj[])\n")
     end
+    _cleanup_hook[] = WeakRef(_cleanup_helper())
+
+    nothing
+end
+
+# these types involve perl objects and should only be touched (deleted)
+# on the main thread
+const pm_perl_types = Union{<:PropertyValue,
+                            <:OptionSet,
+                            <:BigObjectType,
+                            <:BigObject,
+                            <:Polymake.Array{<:BigObject},
+                            <:ListResult,
+                            <:ListResult_internal}
+
+const _pm_cleanup_queue = Base.IntrusiveLinkedListSynchronized{Base.LinkedListItem{pm_perl_types}}()
+
+# overriding the default delete method from cxxwrap
+# to make sure this only runs on the main thread
+# otherwise add it to a global queue
+function CxxWrap.CxxWrapCore.delete(o::pm_perl_types)
+   if Threads.threadid() == 1
+      invoke(CxxWrap.CxxWrapCore.delete, Tuple{Any}, o)
+   else
+      push!(_pm_cleanup_queue, Base.LinkedListItem{pm_perl_types}(o))
+   end
+end
+
+const _cleanup_hook = Ref{WeakRef}()
+
+# adapted from PythonCall.jl
+# kept alive only with a weakref to make sure it will stay
+# on the finalizer list
+mutable struct _cleanup_helper
+   function _cleanup_helper()
+      finalizer(_perlobj_finalizer, new())
+   end
+end
+
+const _count_run = Ref(0)
+const _count_clean = Ref(0)
+const _count_cleanobj = Ref(0)
+
+function _perlobj_finalizer(x)
+   global _count_run[] += 1
+   # only run on main thread
+   if Threads.threadid() != 1
+      # keep self (partially) alive
+      finalizer(_perlobj_finalizer, x)
+      return nothing
+   end
+   global _count_clean[] += 1
+   while !isempty(_pm_cleanup_queue)
+      # clean queued objects
+      global _count_cleanobj[] += 1
+      o = popfirst!(_pm_cleanup_queue)
+      invoke(CxxWrap.CxxWrapCore.delete, Tuple{Any}, o)
+   end
+   # keep self (partially) alive
+   finalizer(_perlobj_finalizer, x)
+   nothing
 end
 
 include("setup_apps.jl")

--- a/src/Polymake.jl
+++ b/src/Polymake.jl
@@ -307,7 +307,6 @@ function __init__()
     # the data will be cleaned anyway once the iddict is cleared
     Base.atexit() do
         Polymake.oscarnumber_prepare_cleanup()
-        ccall(:jl_safe_printf, Cvoid, (Cstring, ), "cleanup: $(_count_run[]), $(_count_clean[]), $(_count_cleanobj[])\n")
     end
     _cleanup_hook[] = WeakRef(_cleanup_helper())
 
@@ -348,22 +347,15 @@ mutable struct _cleanup_helper
    end
 end
 
-const _count_run = Ref(0)
-const _count_clean = Ref(0)
-const _count_cleanobj = Ref(0)
-
 function _perlobj_finalizer(x)
-   global _count_run[] += 1
    # only run on main thread
    if Threads.threadid() != 1
       # keep self (partially) alive
       finalizer(_perlobj_finalizer, x)
       return nothing
    end
-   global _count_clean[] += 1
    while !isempty(_pm_cleanup_queue)
       # clean queued objects
-      global _count_cleanobj[] += 1
       o = popfirst!(_pm_cleanup_queue)
       invoke(CxxWrap.CxxWrapCore.delete, Tuple{Any}, o)
    end


### PR DESCRIPTION
to make sure they are deleted on the main thread

~~currently with a debug print at process end to check statistics~~

It might be better to move this to the c++ side by overriding the finalizer on the libcxxwrap side (instead of relying on overriding the internal `CxxWrap.CxxWrapCore.delete` function), but for now this does seem to work.

cc: @fingolfin 